### PR TITLE
Advertise TOTP instead of Google

### DIFF
--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -10,7 +10,7 @@ $labels['two_step_verification_form'] = '2-Step Verification';
 
 $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';
-$labels['msg_infor'] = 'You can add a <i>secret</i> generated with <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> and use that';
+$labels['msg_infor'] = 'You can scan this QR code using a TOTP compatible app.';
 
 $labels['show_secret'] = 'Show secret';
 $labels['hide_secret'] = 'Hide secret';
@@ -25,7 +25,7 @@ $labels['hide_recovery_codes'] = 'Hide recovery codes';
 
 $labels['setup_all_fields'] = 'Setup all fields (needs Save)';
 
-$labels['enrollment_dialog_title'] = '2steps Google verification';
+$labels['enrollment_dialog_title'] = '2steps OTP verification';
 $labels['enrollment_dialog_msg'] = '<strong>2-steps verification codes</strong> are required for safety, please config';
 
 $labels['check_code'] = 'Check code';

--- a/localization/nl_NL.inc
+++ b/localization/nl_NL.inc
@@ -2,12 +2,12 @@
 // Labels used for different portions of the plugin
 $labels = array();
 $labels['activate'] = 'Activeren';
-$labels['twofactor_gauthenticator'] = '2steps Google verification';
+$labels['twofactor_gauthenticator'] = '2-staps verificatie';
 $labels['code'] = 'Google Authenticator Code';
 $labels['two_step_verification_form'] = '2-staps verificatie';
 $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';
-$labels['msg_infor'] = 'Je kunt een <i>secret</i> genereren via <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> en die hier gebruiken.';
+$labels['msg_infor'] = 'Scan deze QR code met een TOTP app, beschikbaar op de meeste platformen.';
 $labels['show_secret'] = 'Secret weergeven';
 $labels['hide_secret'] = 'Secret verbergen';
 $labels['create_secret'] = 'Secret aanmaken';


### PR DESCRIPTION
As this plugin does RFC 6238 and not really anything Google specific it seems better to describe it that way.

It would also be nice to link to a list of free clients.