### PR TITLE
removed rc deprecated functions and vars

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -99,8 +99,8 @@ class twofactor_gauthenticator extends rcube_plugin
                         }
 
 
-			$code = rcube_utils::get_input_value('_code_2FA', RCUBE_INPUT_POST);
-			$remember = rcube_utils::get_input_value('_remember_2FA', RCUBE_INPUT_POST);
+			$code = rcube_utils::get_input_value('_code_2FA', rcube_utils::INPUT_POST);
+			$remember = rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST);
 
 			if($code)
 			{
@@ -111,7 +111,7 @@ class twofactor_gauthenticator extends rcube_plugin
 						self::__consumeRecoveryCode($code);
 					}
 
-                                        if (rcube_utils::get_input_value('_remember_2FA', RCUBE_INPUT_POST) === 'yes') {
+                                        if (rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST) === 'yes') {
                                             $this->__cookie($set = true);
                                         }
 
@@ -190,14 +190,14 @@ class twofactor_gauthenticator extends rcube_plugin
         $rcmail->output->set_pagetitle($this->gettext('twofactor_gauthenticator'));
         
         // POST variables
-        $activar = rcube_utils::get_input_value('2FA_activate', RCUBE_INPUT_POST);
-        $secret = rcube_utils::get_input_value('2FA_secret', RCUBE_INPUT_POST);
-        $recovery_codes = rcube_utils::get_input_value('2FA_recovery_codes', RCUBE_INPUT_POST);
+        $activar = rcube_utils::get_input_value('2FA_activate', rcube_utils::INPUT_POST);
+        $secret = rcube_utils::get_input_value('2FA_secret', rcube_utils::INPUT_POST);
+        $recovery_codes = rcube_utils::get_input_value('2FA_recovery_codes', rcube_utils::INPUT_POST);
         
         // remove recovery codes without value
         $recovery_codes = array_values(array_diff($recovery_codes, array('')));        
         
-		$data = self::__get2FAconfig();
+        $data = self::__get2FAconfig();
        	$data['secret'] = $secret;
        	$data['activate'] = $activar ? true : false;
        	$data['recovery_codes'] = $recovery_codes;
@@ -206,9 +206,9 @@ class twofactor_gauthenticator extends rcube_plugin
         // if we can't save time into SESSION, the plugin logouts
         $_SESSION['twofactor_gauthenticator_2FA_login'] = time;        
         
-		$rcmail->output->show_message($this->gettext('successfully_saved'), 'confirmation');
+	$rcmail->output->show_message($this->gettext('successfully_saved'), 'confirmation');
          
-        rcmail_overwrite_action('plugin.twofactor_gauthenticator');
+        //rcmail_overwrite_action('plugin.twofactor_gauthenticator');
         $rcmail->output->send('plugin');
     }
   
@@ -325,9 +325,10 @@ class twofactor_gauthenticator extends rcube_plugin
     
     // used with ajax
     function checkCode() {
-    	$code = rcube_utils::get_input_value('code', RCUBE_INPUT_GET);
-    	$secret = rcube_utils::get_input_value('secret', RCUBE_INPUT_GET);
-    	
+    	$code = rcube_utils::get_input_value('code', rcube_utils::INPUT_GET);
+    	//$secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
+    	$secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
+
     	if(self::__checkCode($code, $secret))
     	{
     		echo $this->gettext('code_ok');

--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -208,7 +208,7 @@ class twofactor_gauthenticator extends rcube_plugin
         
 	$rcmail->output->show_message($this->gettext('successfully_saved'), 'confirmation');
          
-        //rcmail_overwrite_action('plugin.twofactor_gauthenticator');
+        $rcmail->overwrite_action('plugin.twofactor_gauthenticator');
         $rcmail->output->send('plugin');
     }
   


### PR DESCRIPTION
Removed RCUBE_INPUT_POST|GET and rcmail_overwrite_action

checked with 1.0.9, 1.1.7, 1.2.3 (complete version) and github version (php 5.6.27 and php 7.0.12, both versions)

Closes #62 (and maybe #61)