### PR TITLE
Reduce length of string description

### DIFF
--- a/twofactor_gauthenticator.js
+++ b/twofactor_gauthenticator.js
@@ -46,7 +46,7 @@ if (window.rcmail) {
 			});
 			
 			// add qr-code before msg_infor
-			var url_qr_code_values = 'otpauth://totp/Roundcube:%20' +$('#prefs-title').html().split(/ - /)[1]+ '?secret=' +$('#2FA_secret').get(0).value +'&issuer=RoundCube2FA%20'+window.location.hostname;
+			var url_qr_code_values = 'otpauth://totp/' +$('#prefs-title').html().split(/ - /)[1]+ '?secret=' +$('#2FA_secret').get(0).value +'&issuer=RoundCube2FA%20'+window.location.hostname;
 			$('table tr:last').before('<tr><td>' +rcmail.gettext('qr_code', 'twofactor_gauthenticator')+ '</td><td><input type="button" class="button mainaction" id="2FA_change_qr_code" value="' 
 					+rcmail.gettext('hide_qr_code', 'twofactor_gauthenticator')+ '"><div id="2FA_qr_code" style="display: visible; margin-top: 10px;"></div></td></tr>');
 			


### PR DESCRIPTION
'Roundcube2FA' is already displayed in the string description, so having 'roundcube:' as a prefix to the account name wastes valuable screen space and may make it impossible to tell on the GA app which code is for which account.