### PR TITLE
Rework form display code with new config settings

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -5,3 +5,11 @@ $rcmail_config['force_enrollment_users'] = false;
 // whitelist, CIDR format available
 // NOTE: we need to use .0 IP to define LAN because the class CIDR have a issue about that (we can't use 129.168.1.2/24, for example)
 $rcmail_config['whitelist'] = array('192.168.1.0/24', '::1', '192.168.0.9');
+
+// Admin can disable saving devices for all users (paranoid mode)
+// Default: allow saving devices (true)
+$rcmail_config['allow_save_device_30days'] = true;
+
+// Make the 2-step field a masked password input type
+// Default: form field will be text (false)
+$rcmail_config['twofactor_formfield_as_password'] = false;

--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -45,6 +45,10 @@ class twofactor_gauthenticator extends rcube_plugin
 		$this->register_action('plugin.twofactor_gauthenticator-save', array($this, 'twofactor_gauthenticator_save'));
 		$this->include_script('twofactor_gauthenticator.js');
 		$this->include_script('qrcode.min.js');
+		
+		// settings we will export to the form javascript
+		$this->api->output->set_env('allow_save_device_30days',$rcmail->config->get('allow_save_device_30days',true));
+		$this->api->output->set_env('twofactor_formfield_as_password',$rcmail->config->get('twofactor_formfield_as_password',false));
     }
     
     

--- a/twofactor_gauthenticator_form.js
+++ b/twofactor_gauthenticator_form.js
@@ -9,19 +9,26 @@ if (window.rcmail) {
     $('form').attr('action', './');
     $('input[name=_task]').attr('value', 'mail');
     $('input[name=_action]').attr('value', '');
-	  
+
+	//determine twofactor field type based on config settings
+	if(rcmail.env.twofactor_formfield_as_password)
+		var twoFactorCodeFieldType = 'password';
+	else
+		var twoFactorCodeFieldType = 'text';
+	
+	//twofactor input form
     var text = '';
     text += '<tr>';
     text += '<td class="title"><label for="2FA_code">'+rcmail.gettext('two_step_verification_form', 'twofactor_gauthenticator')+'</label></td>';
-    text += '<td class="input"><input name="_code_2FA" id="2FA_code" size="10" autocapitalize="off" autocomplete="off" type="text" maxlength="10" style="width: 100px;"></td>';
+    text += '<td class="input"><input name="_code_2FA" id="2FA_code" size="10" autocapitalize="off" autocomplete="off" type="' + twoFactorCodeFieldType + '" maxlength="10"></td>';
     text += '</tr>';
 
     // remember option
-    text += '<tr>';
-//    text += '<td colspan="2"><label style="color: #fefefe"><input type="checkbox" id="remember_2FA" name="_remember_2FA" value="yes"/>'+rcmail.gettext('dont_ask_me_30days', 'twofactor_gauthenticator')+'</label></td>';
-    text += '<td class="title" colspan="2"><input type="checkbox" id="remember_2FA" name="_remember_2FA" value="yes"/>'+rcmail.gettext('dont_ask_me_30days', 'twofactor_gauthenticator')+'</td>';
-    text += '</tr>';
-
+    if(rcmail.env.allow_save_device_30days){
+		text += '<tr>';
+		text += '<td class="input" colspan="2"><input type="checkbox" id="remember_2FA" name="_remember_2FA" value="yes"/>'+rcmail.gettext('dont_ask_me_30days', 'twofactor_gauthenticator')+'</td>';
+		text += '</tr>';
+	}
 
     // create textbox
     $('form > table > tbody:last').append(text);


### PR DESCRIPTION
-Added config setting to globally enable/disable checkbox allowing users to save device for 30 days (paranoid security mode).  

-changed class on remember device 30 days to be "input" from "title" to fix display in some skins

-Added config setting to force 2-factor code input field to be password field.  (this is required for keepass TOTP to auto-type input into textbox)