### PR TITLE
Use crypto.getRandomValues instead of Math.random to generate secrets

### DIFF
--- a/twofactor_gauthenticator.js
+++ b/twofactor_gauthenticator.js
@@ -2,26 +2,27 @@ if (window.rcmail) {
   rcmail.addEventListener('init', function(evt) {
 
 	  // ripped from PHPGansta/GoogleAuthenticator.php
-		function createSecret(secretLength)
-		{
+		function createSecret(secretLength) {
 			if(!secretLength) secretLength = 16;
-			
-		    LookupTable = new Array(
+
+			var lookupTable = new Array(
 		            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', //  7
 		            'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', // 15
 		            'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', // 23
 		            'Y', 'Z', '2', '3', '4', '5', '6', '7' // 31
 		            //'='  // padding char
 		        );
-		
-		    secret = '';
-		    for (i = 0; i < secretLength; i++) {
-		        secret += LookupTable[Math.floor(Math.random()*LookupTable.length)];
-		    }
-		    return secret;
+
+			var secret = '';
+			var random = new Uint8Array(secretLength);
+			var cryptoapi = window.crypto || window.msCrypto; // Support IE11 for now
+			cryptoapi.getRandomValues(random);
+			for (var i = 0; i < secretLength; i++) {
+				secret += lookupTable[random[i]%lookupTable.length];
+			}
+			return secret;
 		}
 
-		
 		// populate all fields
 		function setup2FAfields() {
 			if($('#2FA_secret').get(0).value) return;


### PR DESCRIPTION
Math.random is not cryptographically secure and thus should not be used to generate secrets. The Web Cryptography API used here is supported from IE 11, Firefox 34, Chrome 37 and Safari 11 onwards. That is a bit less than what Roundcube itself supports, but still very reasonable considering that this feature will be used by security conscious people who will most likely not be running massively out-of-date browsers.