### PR TITLE
Fix/woraround: Click on 2factor settings nothing happen #144

### DIFF
--- a/twofactor_gauthenticator.js
+++ b/twofactor_gauthenticator.js
@@ -145,7 +145,7 @@ if (window.rcmail) {
       .attr('href', rcmail.env.comm_path + '&_action=plugin.twofactor_gauthenticator')
       .html(rcmail.gettext('twofactor_gauthenticator', 'twofactor_gauthenticator'))
       .attr('role', 'button') 
-      .attr('onclick', 'return rcmail.command(\'show\', \'plugin.twofactor_gauthenticator\', this, event)') 
+      //.attr('onclick', 'return rcmail.command(\'show\', \'plugin.twofactor_gauthenticator\', this, event)') 
       .attr('tabindex', '0') 
       .attr('aria-disabled', 'false')
       .appendTo(tabtwofactorgauthenticator);


### PR DESCRIPTION
dirty fix makes settings clickable.
refers to bug report https://github.com/alexandregz/twofactor_gauthenticator/issues/144