### PR TITLE
Update twofactor_gauthenticator.php for reverse proxy use

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -135,7 +135,16 @@ class twofactor_gauthenticator extends rcube_plugin
 			// with IP allowed, we don't need to check anything
 			if($rcmail->config->get('whitelist')) {
 				foreach($rcmail->config->get('whitelist') as $ip_to_check) {
-					if(CIDR::match($_SERVER['REMOTE_ADDR'], $ip_to_check)) {
+					if (isset($_SERVER['HTTP_CLIENT_IP']) && array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
+						$realip = $_SERVER['HTTP_CLIENT_IP'];
+					} elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
+						$realips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+						$realips = array_map('trim', $realips);
+						$realip = $realips[0];
+					} else {
+						$realip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+					}
+					if(CIDR::match($realip, $ip_to_check)) {
 						if(isset($_SESSION['twofactor_gauthenticator_login'])) {
 							if($rcmail->task === 'login') $this->__goingRoundcubeTask('mail');
 							return $p;


### PR DESCRIPTION
Extend whitelisting in case of a reverse proxy between client and roundcube.