### PR TITLE
Updating the readme and adding a link to the user-manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Installation
 
 Configuration
 -------------
-Go to the Settings task and in the "2steps Google verification" menu, click 'Setup all fields (needs Save)'.
+Copy `HOME_RC/plugins/twofactor_gauthenticator/config.inc.php.dist` to `HOME_RC/plugins/twofactor_gauthenticator/config.inc.php`.
 
-The plugin automatically creates the secret for you.
+Configure or remove at least the config value "users_allowed_2FA" from config.inc.php and configure other config values to your needs.
 
 NOTE: plugin must be base32 valid characters ([A-Z][2-7]), see https://github.com/alexandregz/twofactor_gauthenticator/blob/master/PHPGangsta/GoogleAuthenticator.php#L18
 
@@ -56,13 +56,13 @@ The first time you open the app you see the default settings:
 
 ![Default Settings](https://github.com/user-attachments/assets/deb6718d-e2e0-4615-bf54-77f1207698d1)
 
-The most easy way to configure the app is by clicking "Fill all fields":
+The most easy way to configure the app is by clicking "Fill all fields". The plugin automatically creates the secret for you:
 
 ![Untitled](https://github.com/user-attachments/assets/e8f0582a-66f7-435b-a2d2-bac94cfd5acd)
 
 Now scan the QR code with any authenticator app, generate a code, enter your new code in the bottom field and press "Check code". If your code is a match, you can press "Save" to save the configuration. 
 
-Alternatively, you can configure the app manually by checking the checkbox and pressing "Save". A secret wil be automatically generated:
+Alternatively, you can configure the app manually by checking the checkbox and pressing "Save". A secret will be automatically generated:
 
 ![Settings OK](https://github.com/user-attachments/assets/12acfd8d-b018-4739-ae01-b77940ca631d)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-2Steps verification
+Two-factor verification
 ==========================
 
-This RoundCube plugin adds the 2-step verification(OTP) to the login proccess.
+This RoundCube plugin adds the 2-step verification (OTP) to the login proccess.
 
 It works with all TOTP applications [RFC 6238](https://www.rfc-editor.org/info/rfc6238)
 
@@ -27,16 +27,16 @@ Also thx to [Victor R. Rodriguez Dominguez](https://github.com/vrdominguez) for 
 Installation
 ------------
 - Clone from github:
-    HOME_RC/plugins$ git clone [https://github.com/alexandregz/twofactor_gauthenticator.git](https://github.com/alexandregz/twofactor_gauthenticator.git)
+    `HOME_RC/plugins$ git clone https://github.com/alexandregz/twofactor_gauthenticator.git`
     
 
 (Or use composer
-     HOME_RC$ composer require alexandregz/twofactor_gauthenticator:dev-master
+     `HOME_RC$ composer require alexandregz/twofactor_gauthenticator:dev-master`
      
  NOTE: Answer **N** when composer ask you about plugin activation)
 
-- Activate the plugin into HOME_RC/config/config.inc.php:
-    $config['plugins'] = array('twofactor_gauthenticator');
+- Activate the plugin into `HOME_RC/config/config.inc.php`:
+    `$config['plugins'] = array('twofactor_gauthenticator');`
 
 
 Configuration
@@ -50,28 +50,27 @@ NOTE: plugin must be base32 valid characters ([A-Z][2-7]), see https://github.co
 From https://github.com/alexandregz/twofactor_gauthenticator/issues/139
 
 
-	
-To add accounts to the app, you can use the QR-Code (easy-way) or type the secret.
-After checking the first code click 'Save'.
+Usage
+----------------
+The first time you open the app you see the default settings:
 
-![Settings by default](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/003-settings_default.png)
+![Default Settings](https://github.com/user-attachments/assets/deb6718d-e2e0-4615-bf54-77f1207698d1)
 
-![Settings OK](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/004-settings_ok.png)
+The most easy way to configure the app is by clicking "Fill all fields":
 
-![QR-Code example](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/005-settings_qr_code.png)
+![Untitled](https://github.com/user-attachments/assets/e8f0582a-66f7-435b-a2d2-bac94cfd5acd)
 
+Now scan the QR code with any authenticator app, generate a code, enter your new code in the bottom field and press "Check code". If your code is a match, you can press "Save" to save the configuration. 
 
-Also, you can add "Recovery codes" for use one time (they delete when are used). Recovery codes are OPTIONAL, so they can be left blank.
+Alternatively, you can configure the app manually by checking the checkbox and pressing "Save". A secret wil be automatically generated:
 
-![Recovery codes](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/006-recovery_codes.png) 
+![Settings OK](https://github.com/user-attachments/assets/12acfd8d-b018-4739-ae01-b77940ca631d)
 
+Now you can press "Show QR code" or use the generated secret to connect to any authenticator app.
 
-![Check codes](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/007-check_code.png) 
+Also, you can add "Recovery codes" for use one time (they are deleted when used). Recovery codes are OPTIONAL, so they can be left blank.
 
-
-
-![Recovery codes](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/008-msg_infor_about_enrollment.png) 
-
+![Recovery codes](https://github.com/user-attachments/assets/dedba088-50c6-423d-8ed8-a1137c37d41d)
 
 
 Enrollment Users
@@ -97,7 +96,7 @@ MIT, see License
 
 Notes
 -----
-Tested with RoundCube 0.9.5 and Google app. Also with Roundcube 1.0.4
+Tested with RoundCube 0.9.5 and Google app. Also with Roundcube 1.0.4 and 1.6.9 with OpenAuthenticator.
 
 Remember, sync time it's essential for TOTP: "For this to work, the clocks of the user's device and the server need to be roughly synchronized (the server will typically accept one-time passwords generated from timestamps that differ by ±1 from the client's timestamp)" (from http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
 

--- a/localization/cs_CZ.inc
+++ b/localization/cs_CZ.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Tajný kód';
 $labels['qr_code'] = 'QR kód';
 $labels['msg_infor'] = 'Zobrazený QR kód, obsahující nastavení pro dvoufázové ověření, můžete použít v TOTP kompatibilní aplikaci jako je <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) nebo <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>.';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Uživatelská příručka</a>';
+
 $labels['show_secret'] = 'Zobrazit tajný kód';
 $labels['hide_secret'] = 'Skrýt tajný kód';
 $labels['create_secret'] = 'Vytvořit tajný kód';

--- a/localization/da_DK.inc
+++ b/localization/da_DK.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Hemmelig kode';
 $labels['qr_code'] = 'QR kode';
 $labels['msg_infor'] = 'Du kan scanne denne QR kode med en TOTP kompatibel app som for eksempel <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>).';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Brugervejledning</a>';
+
 $labels['show_secret'] = 'Vis hemmelig kode';
 $labels['hide_secret'] = 'Skjul hemmelig kode';
 $labels['create_secret'] = 'Generer hemmelig kode';

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR-Code';
 $labels['msg_infor'] = 'Sie k&ouml;nnen mit jeder TOTP kompatiblen App wie z.B. <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) oder <a href="https://github.com/google/google-authenticator" target="_blank">Google-Authenticator</a> ein Secret erstellen und dieses verwenden.';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Benutzerhandbuch</a>';
+
 $labels['show_secret'] = 'Zeige Secret';
 $labels['hide_secret'] = 'Verstecke Secret';
 $labels['create_secret'] = 'Erstelle Secret';

--- a/localization/el_GR.inc
+++ b/localization/el_GR.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Μυστικό Κλειδί (Secret)';
 $labels['qr_code'] = 'QR Code';
 $labels['msg_infor'] = 'Μπορείτε να σαρώσετε τον QR code που περιέχει της ρυθμίσεις διπλής πιστοποίησης (2FA) με μια εφαρμογή TOTP (TOTP app) όπως ο <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) ή <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Εγχειρίδιο χρήσης</a>';
+
 $labels['show_secret'] = 'Εμφάνιση Κλειδιού';
 $labels['hide_secret'] = 'Απόκρυψη Κλειδιού';
 $labels['create_secret'] = 'Δημιουργία Κλειδιού';

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';
 $labels['msg_infor'] = 'You can scan this QR code containing the 2-Factor settings using a TOTP compatible app such as <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) or <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">User manual</a>';
+
 $labels['show_secret'] = 'Show secret';
 $labels['hide_secret'] = 'Hide secret';
 $labels['create_secret'] = 'Create secret';

--- a/localization/es_AR.inc
+++ b/localization/es_AR.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Secreto';
 $labels['qr_code'] = 'Código QR';
 $labels['msg_infor'] = 'Podés agregar una <em>clave</em> generada con <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) o <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manual del usuario</a>';
+
 $labels['show_secret'] = 'Mostrar clave';
 $labels['hide_secret'] = 'Ocultar clave';
 $labels['create_secret'] = 'Generar nueva clave';

--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Secreto';
 $labels['qr_code'] = 'Código QR';
 $labels['msg_infor'] = 'Puedes añadir un <i>secreto</i> generado en tu ordenador con <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) o <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> e usarlo';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manual del usuario</a>';
+
 $labels['show_secret'] = 'Ver secreto';
 $labels['hide_secret'] = 'Esconder secreto';
 $labels['create_secret'] = 'Crear secreto';

--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';
 $labels['msg_infor'] = 'Vous pouvez scanner ce QR code avec une application compatible TOTP comme <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>).';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manuel d\'utilisation</a>';
+
 $labels['show_secret'] = 'Afficher le secret';
 $labels['hide_secret'] = 'Masquer le secret';
 $labels['create_secret'] = 'Créer un secret';

--- a/localization/gl_ES.inc
+++ b/localization/gl_ES.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Segredo';
 $labels['qr_code'] = 'Código QR';
 $labels['msg_infor'] = 'Podes engadir un <i>segredo</i> xerado na tua computadora con <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) o <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> e empregalo';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manual del usuario</a>';
+
 $labels['show_secret'] = 'Ver segredo';
 $labels['hide_secret'] = 'Agochar segredo';
 $labels['create_secret'] = 'Crear segredo';

--- a/localization/he_IL.inc
+++ b/localization/he_IL.inc
@@ -8,6 +8,7 @@ $labels['two_step_verification_form'] = 'קוד אימות דו-שלבי:';
 $labels['secret'] = 'קוד סודי';
 $labels['qr_code'] = 'QR קוד';
 $labels['msg_infor'] = 'תוכל לסרוד קוד QR זה המכיל הגדרות אימות דו-שלבי על ידי אפליקצייה התומכת ב-TOTP כמו <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) or <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>';
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">מדריך למשתמש</a>';
 $labels['show_secret'] = 'הראה קוד סודי';
 $labels['hide_secret'] = 'הסתר קוד סודי';
 $labels['create_secret'] = 'צור קודי סודי';

--- a/localization/hu_HU.inc
+++ b/localization/hu_HU.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Titok';
 $labels['qr_code'] = 'QR-kód';
 $labels['msg_infor'] = 'Beolvashatja ezt a kétfaktoros beállításokat tartalmazó QR-kódot egy TOTP kompatibilis alkalmazással, mint pl. a <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) vagy <a href="https://github.com/google/google-authenticator" target="_blank">Google Hitelesítő</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Felhasználói kézikönyv</a>';
+
 $labels['show_secret'] = 'Titok mutatása';
 $labels['hide_secret'] = 'Titok elrejtése';
 $labels['create_secret'] = 'Titok készítése';

--- a/localization/it_IT.inc
+++ b/localization/it_IT.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'Codice QR';
 $labels['msg_infor'] = 'Puoi aggiungere un <i>secret</i> generato con <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) o <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> e utilizzare quello';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manuale d\'uso</a>';
+
 $labels['show_secret'] = 'Mostra secret';
 $labels['hide_secret'] = 'Nascondi secret';
 $labels['create_secret'] = 'Crea secret';

--- a/localization/ja_JP.inc
+++ b/localization/ja_JP.inc
@@ -11,6 +11,7 @@ $labels['two_step_verification_form'] = '二段階認証';
 $labels['secret'] = '秘密鍵';
 $labels['qr_code'] = 'QRコード';
 $labels['msg_infor'] = 'ここに <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) または <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> で作成した<i>秘密鍵</i>を追加して使用できます';
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">ユーザーマニュアル</a>';
 $labels['show_secret'] = '秘密鍵表示';
 $labels['hide_secret'] = '秘密鍵非表示';
 $labels['create_secret'] = '秘密鍵作成';

--- a/localization/lv_LV.inc
+++ b/localization/lv_LV.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Drošības kods';
 $labels['qr_code'] = 'QR Kods';
 $labels['msg_infor'] = 'Jūs varat noskenēt QR kodu izmantojot <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) arba <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> aplikāciju';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Naudotojo vadovas</a>';
+
 $labels['show_secret'] = 'Parādīt drošības kodu';
 $labels['hide_secret'] = 'Paslēpt drošības kodu';
 $labels['create_secret'] = 'Izveidot drošības kodu';

--- a/localization/nb_NO.inc
+++ b/localization/nb_NO.inc
@@ -13,6 +13,8 @@ $labels['secret'] = 'Hemmelighet';
 $labels['qr_code'] = 'QR-kode';
 $labels['msg_infor'] = 'You can add a <i>secret</i> generated with <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) or <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> and use that';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">User manual</a>';
+
 $labels['show_secret'] = 'Vis hemmeligheten';
 $labels['hide_secret'] = 'Skjul hemmeligheten';
 $labels['create_secret'] = 'Ny hemmelighet';

--- a/localization/nl_NL.inc
+++ b/localization/nl_NL.inc
@@ -8,6 +8,7 @@ $labels['two_step_verification_form'] = '2-staps verificatie';
 $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';
 $labels['msg_infor'] = 'Scan deze QR code met een TOTP app, beschikbaar op de meeste platformen, zoals bijvoorbeeld <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>).';
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Gebruiksaanwijzing</a>';
 $labels['show_secret'] = 'Secret weergeven';
 $labels['hide_secret'] = 'Secret verbergen';
 $labels['create_secret'] = 'Secret aanmaken';

--- a/localization/nn_NO.inc
+++ b/localization/nn_NO.inc
@@ -13,6 +13,8 @@ $labels['secret'] = 'Hemmelegheit';
 $labels['qr_code'] = 'QR-kode';
 $labels['msg_infor'] = 'You can add a <i>secret</i> generated with <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) or <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> and use that';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">User manual</a>';
+
 $labels['show_secret'] = 'Vis hemmelegheita';
 $labels['hide_secret'] = 'Skjul hemmelegheita';
 $labels['create_secret'] = 'Ny hemmelegheit';

--- a/localization/pl_PL.inc
+++ b/localization/pl_PL.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Tajny klucz';
 $labels['qr_code'] = 'Kod QR';
 $labels['msg_infor'] = 'Możesz dodać <i>tajny kod</i> wygenerowany przez aplikację <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) lub <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> i użyć go';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Podręcznik użytkownika</a>';
+
 $labels['show_secret'] = 'Pokaż tajny klucz';
 $labels['hide_secret'] = 'Ukryj tajny klucz';
 $labels['create_secret'] = 'Generuj tajny klucz';

--- a/localization/pt_BR.inc
+++ b/localization/pt_BR.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Contra Senha';
 $labels['qr_code'] = 'QR Code';
 $labels['msg_infor'] = 'Escaneie o QR code abaixo com um aplicativo TOTP, como o Authy na sua versão <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) ou <a href="https://play.google.com/store/apps/details?id=com.authy.authy" target="_blank">Android - Play Store</a> ou  em sua versão <a href="https://itunes.apple.com/br/app/authy/id494168017" target="_blank">Apple iOS - AppStore</a>.';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Manual do usuário</a>';
+
 $labels['show_secret'] = 'Mostrar contra senha';
 $labels['hide_secret'] = 'Esconder contra senha';
 $labels['create_secret'] = 'Criar contra senha';

--- a/localization/ru_RU.inc
+++ b/localization/ru_RU.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Ключ';
 $labels['qr_code'] = 'QR-код';
 $labels['msg_infor'] = 'Вы можете добавить <i>ключ</i> сгенерированный <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) или <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> и использовать его';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Руководство пользователя</a>';
+
 $labels['show_secret'] = 'Показать ключ';
 $labels['hide_secret'] = 'Скрыть ключ';
 $labels['create_secret'] = 'Создать ключ';

--- a/localization/sk_SK.inc
+++ b/localization/sk_SK.inc
@@ -11,6 +11,8 @@ $labels['secret'] = 'Tajný kód';
 $labels['qr_code'] = 'QR kód';
 $labels['msg_infor'] = 'Zobrazený QR kód, obsahujúcí nastavenia pro dvojstupňové overenie, môžete naskenovať v TOTP kompatibilnej aplikácii jako je napr. <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) alebo <a href="https://en.wikipedia.org/wiki/Google_Authenticator" target="_blank">Google Authenticator</a> alebo <a href="https://authy.com/" target="_blank">Authy</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Používateľská príručka</a>';
+
 $labels['show_secret'] = 'Zobraziť tajný kód';
 $labels['hide_secret'] = 'Skryť tajný kód';
 $labels['create_secret'] = 'Vytvoriť tajný kód';

--- a/localization/sv_SE.inc
+++ b/localization/sv_SE.inc
@@ -12,6 +12,8 @@ $labels['qr_code'] = 'QR-kod';
 
 $labels['msg_infor'] = 'Du kan scanna QR-koden innehållande din hemliga nyckel med en TOTP kompatibel applikation, typ <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) eller <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Bruksanvisning</a>';
+
 $labels['show_secret'] = 'Visa hemlig nyckel';
 $labels['hide_secret'] = 'Dölj hemlig nyckel';
 $labels['create_secret'] = 'Skapa hemlig nyckel';

--- a/localization/tr_TR.inc
+++ b/localization/tr_TR.inc
@@ -13,6 +13,8 @@ $labels['msg_infor'] = 'İki faktörlü doğrulama için Android veya IOS İşle
 Android : <a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Uygulamaya git</a><br>
 IOS : <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Uygulamaya git</a>';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Kullanıcı kılavuzu</a>';
+
 $labels['show_secret'] = 'Gizli Kodu Göster';
 $labels['hide_secret'] = 'Kodu Gizle';
 $labels['create_secret'] = 'Giz kod oluştur';

--- a/localization/uk_UA.inc
+++ b/localization/uk_UA.inc
@@ -12,6 +12,8 @@ $labels['secret'] = 'Ключ';
 $labels['qr_code'] = 'QR-код';
 $labels['msg_infor'] = 'Ви можете додати <i>ключ</i> згенерований <a href="https://github.com/Skyost/OpenAuthenticator" target="_blank">OpenAuthenticator</a> (<a href="https://play.google.com/store/apps/details?id=app.openauthenticator" target="_blank">Play Store</a> | <a href="https://apps.apple.com/us/app/open-authenticator-by-skyost/id6479272927" target="_blank">Istore</a>) або <a href="https://github.com/google/google-authenticator" target="_blank">google-authenticator</a> та використовувати його';
 
+$labels['msg_help'] = '<a href="https://github.com/alexandregz/twofactor_gauthenticator/tree/master?tab=readme-ov-file#usage" target="_blank">Посібник користувача</a>';
+
 $labels['show_secret'] = 'Показати ключ';
 $labels['hide_secret'] = 'Приховати ключ';
 $labels['create_secret'] = 'Створити ключ';

--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -354,7 +354,7 @@ class twofactor_gauthenticator extends rcube_plugin
         
         $html_check_code = '<br /><br /><input type="button" class="button mainaction" id="2FA_check_code" value="'.$this->gettext('check_code').'"> &nbsp;&nbsp; <input type="text" id="2FA_code_to_check" maxlength="10">';
         
-        
+        $html_help_code = '<br /><br /> &#9432; '.$this->gettext('msg_help');
         
         // Build the table with the divs around it
         $out = html::div(array('class' => 'settingsbox', 'style' => 'margin: 0;'),
@@ -374,6 +374,7 @@ class twofactor_gauthenticator extends rcube_plugin
             		// button to setup all fields
             		.$html_setup_all_fields
             		.$html_check_code
+            		.$html_help_code
                 )
         	)
         );


### PR DESCRIPTION
Many of my webmail users simply enable the feature and log out without connecting to any authenticator app. As a result, I must remove the Authenticator settings directly in mariadb, so they can start over. 

I've tried improving the readme-section with more up-to date images, better formatting, updated the configuration-section to include config.inc.php and a separate section for usage instructions. In addition to that, I've added a link to this new section in the readme file from the settings page. The purpose of this update is to provide clear usage instructions to webmail users.