### PR TITLE
Remove Google specific translation string

### DIFF
--- a/localization/cs_CZ.inc
+++ b/localization/cs_CZ.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Zapnout';
 $labels['twofactor_gauthenticator'] = 'Dvoufázové ověření';
-$labels['code'] = 'Google Authenticator kód';
+$labels['code'] = 'Ověření kód';
 
 $labels['two_step_verification_form'] = 'Kód dvoufázového ověření:';
 

--- a/localization/da_DK.inc
+++ b/localization/da_DK.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Aktiver';
 $labels['twofactor_gauthenticator'] = '2-trins verificering';
-$labels['code'] = 'Google Autentificerings kode';
+$labels['code'] = 'Autentificering kode';
 
 $labels['two_step_verification_form'] = '2-trins verificering';
 

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Aktivieren';
 $labels['twofactor_gauthenticator'] = 'Zwei-Faktor-Authentifizierung';
-$labels['code'] = 'Google-Authenticator-Code';
+$labels['code'] = 'Authentifizierung-Code';
 
 $labels['two_step_verification_form'] = 'Zwei-Faktor-Best&auml;tigungscode';
 

--- a/localization/el_GR.inc
+++ b/localization/el_GR.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Ενεργοποίηση';
 $labels['twofactor_gauthenticator'] = 'Διπλή Πιστοποίηση <br>(2-Factor Authentication)';
-$labels['code'] = 'Κωδικός TOTP <br>(Google Authenticator Code)';
+$labels['code'] = 'πιστοποίηση TOTP';
 
 $labels['two_step_verification_form'] = 'Δπλή πιστοποίηση (2FA):';
 

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Activate';
 $labels['twofactor_gauthenticator'] = '2-Factor Authentication';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Authentication Code';
 
 $labels['two_step_verification_form'] = '2-Factor Authentication Code:';
 

--- a/localization/es_AR.inc
+++ b/localization/es_AR.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Activar';
 $labels['twofactor_gauthenticator'] = 'Verificación de Google de dos pasos';
-$labels['code'] = 'Código de Google Authenticator';
+$labels['code'] = 'Código de autenticación';
 
 $labels['two_step_verification_form'] = 'Verificación de dos pasos';
 

--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Activar';
 $labels['twofactor_gauthenticator'] = '2steps Google verification';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Verificación Code';
 
 $labels['two_step_verification_form'] = 'Verificación de dos pasos';
 

--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Activer';
 $labels['twofactor_gauthenticator'] = 'Authentification en 2 étapes';
-$labels['code'] = 'Code Google Authenticator';
+$labels['code'] = 'Code d\'authentification';
 
 $labels['two_step_verification_form'] = 'Vérification en 2 étapes';
 

--- a/localization/gl_ES.inc
+++ b/localization/gl_ES.inc
@@ -4,7 +4,7 @@ $labels = array();
 
 $labels['activate'] = 'Activar';
 $labels['twofactor_gauthenticator'] = '2steps Google verification';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Código de autenticación';
 
 $labels['two_step_verification_form'] = 'Verificación de dous pasos';
 

--- a/localization/hu_HU.inc
+++ b/localization/hu_HU.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Aktiválás';
 $labels['twofactor_gauthenticator'] = 'Kétfaktoros bejelentkezés';
-$labels['code'] = 'Google hitelesítő kód';
+$labels['code'] = 'Hitelesítési kód';
 
 $labels['two_step_verification_form'] = 'Kétfaktoros hitelesítő kód:';
 

--- a/localization/it_IT.inc
+++ b/localization/it_IT.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Attiva';
 $labels['twofactor_gauthenticator'] = 'Verifica in due passaggi Google';
-$labels['code'] = 'Codice d\'autenticazione Google';
+$labels['code'] = 'Codice di autenticazione';
 
 $labels['two_step_verification_form'] = 'Verifica in due passaggi';
 

--- a/localization/ja_JP.inc
+++ b/localization/ja_JP.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = '有効';
 $labels['twofactor_gauthenticator'] = 'Google二段階認証';
-$labels['code'] = 'Google認証コード';
+$labels['code'] = '認証コード';
 
 $labels['two_step_verification_form'] = '二段階認証';
 

--- a/localization/lv_LV.inc
+++ b/localization/lv_LV.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Aktivizēt';
 $labels['twofactor_gauthenticator'] = '2-Faktoru Autentifikators';
-$labels['code'] = 'Google Aotentifikatora kods';
+$labels['code'] = 'Autentifikācijas kods';
 
 $labels['two_step_verification_form'] = '2-Faktoru autentifikācijas kods:';
 

--- a/localization/nb_NO.inc
+++ b/localization/nb_NO.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Aktiver';
 $labels['twofactor_gauthenticator'] = '2-trinns Google bekreftelse';
-$labels['code'] = 'Google-autentisering kode';
+$labels['code'] = 'Autentiseringskode';
 
 $labels['two_step_verification_form'] = '2-trinns bekreftelse';
 $labels['remember_computer'] = 'Husk denne datamaskinen';

--- a/localization/nl_NL.inc
+++ b/localization/nl_NL.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Activeren';
 $labels['twofactor_gauthenticator'] = '2-staps verificatie';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Authenticatiecode';
 $labels['two_step_verification_form'] = '2-staps verificatie';
 $labels['secret'] = 'Secret';
 $labels['qr_code'] = 'QR Code';

--- a/localization/nn_NO.inc
+++ b/localization/nn_NO.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Aktiver';
 $labels['twofactor_gauthenticator'] = '2-trinns Google verifikasjon';
-$labels['code'] = 'Google-autentisering kode';
+$labels['code'] = 'Autentiseringskode';
 
 $labels['two_step_verification_form'] = '2-trinns verifikasjon';
 $labels['remember_computer'] = 'Hugs denne datamaskinen';

--- a/localization/pl_PL.inc
+++ b/localization/pl_PL.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Aktywuj';
 $labels['twofactor_gauthenticator'] = 'Dwuskładnikowe uwierzytelnianie';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Kod uwierzytelniający';
 
 $labels['two_step_verification_form'] = 'Podaj hasło jednorazowe';
 

--- a/localization/pt_BR.inc
+++ b/localization/pt_BR.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Ativar';
 $labels['twofactor_gauthenticator'] = 'Verificação em Duas Etapas';
-$labels['code'] = 'Google Authenticator Code';
+$labels['code'] = 'Código de autenticação';
 
 $labels['two_step_verification_form'] = 'Código da Verificação em Duas Etapas [2FA]:';
 

--- a/localization/ru_RU.inc
+++ b/localization/ru_RU.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Активировать';
 $labels['twofactor_gauthenticator'] = 'Двухэтапная аутентификация';
-$labels['code'] = 'Код Google аутентификации';
+$labels['code'] = 'Код аутентификации';
 
 $labels['two_step_verification_form'] = 'Двухэтапная Аутентификация';
 

--- a/localization/sk_SK.inc
+++ b/localization/sk_SK.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Zapnúť';
 $labels['twofactor_gauthenticator'] = 'Dvojstupňové overenie';
-$labels['code'] = 'Google Authenticator kód';
+$labels['code'] = 'Autentifikačný kód';
 
 $labels['two_step_verification_form'] = 'Kód dvojstupňového overenia:';
 

--- a/localization/tr_TR.inc
+++ b/localization/tr_TR.inc
@@ -3,7 +3,7 @@
 $labels = array();
 $labels['activate'] = 'Aktif Et';
 $labels['twofactor_gauthenticator'] = 'İki Faktörlü Doğrulama (2FA)';
-$labels['code'] = 'Google Authenticator Kodu';
+$labels['code'] = 'Kimlik Doğrulama Kodu';
 
 $labels['two_step_verification_form'] = '2-Faktörlü Doğrulama Kodu:';
 

--- a/localization/uk_UA.inc
+++ b/localization/uk_UA.inc
@@ -4,7 +4,7 @@
 $labels = array();
 $labels['activate'] = 'Активувати';
 $labels['twofactor_gauthenticator'] = 'Двоетапна автентифікація';
-$labels['code'] = 'Код Google автентифікації';
+$labels['code'] = 'Код автентифікації';
 
 $labels['two_step_verification_form'] = 'Двоетапна Аутентифікація';
 


### PR DESCRIPTION
Instead of asking for "Google Authenticator code", you want to provide a more neutral and platform independent way of asking for the TOTP code, like: "**Authentication code**". I fixed this translation string for ALL translations (if applicable).

Fixes: https://github.com/alexandregz/twofactor_gauthenticator/issues/208