### PR TITLE
Fix php linting + small config & README improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 .project
 .buildpath
 .settings*
+.php-cs-fixer.cache
 config.inc.php
 #### joe made this: https://goel.io/joe
+
+tools/php-cs-fixer/vendor
 
 #####=== Vim ===#####
 [._]*.s[a-w][a-z]

--- a/CIDR.php
+++ b/CIDR.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CIDR class helps validate an ip address against a CIDR ip range.
  *
@@ -11,155 +12,147 @@
  * @copyright   Copyright (c) 2015 Frank Forte
  * @license     BSD-3 License https://opensource.org/licenses/BSD-3-Clause
  */
-class CIDR{
+class CIDR
+{
+    /**
+     * compare an IPv4 or IPv6 address with a CIDR address or range
+     *
+     * @param  string  $address a valid IPv6 address
+     * @param  string  $subnet a valid IPv6 subnet[/mask]
+     * @return boolean	whether $address is within the ip range made up  of the subnet and mask
+     */
+    public static function match($ip, $cidr)
+    {
 
-   /**
-	* compare an IPv4 or IPv6 address with a CIDR address or range
-	*
-	* @param  string  $address a valid IPv6 address
-	* @param  string  $subnet a valid IPv6 subnet[/mask]
-	* @return boolean	whether $address is within the ip range made up  of the subnet and mask
-	*/
-    public static function match($ip, $cidr){
-		
-		// make sure we compare ip addresses as case insensitive
-		$ip = strtolower($ip);
-		$cidr = strtolower($cidr);
-		
-		// comparing exact ip?
-		if($ip == $cidr){ return true; }
+        // make sure we compare ip addresses as case insensitive
+        $ip = strtolower($ip);
+        $cidr = strtolower($cidr);
 
-		
-		if(strpos($cidr,'/') !== false){
-			 list($subnet, $mask) = explode('/', $cidr);
-		} else {
-			$subnet = $cidr;
-			$mask = 0;
-		}
+        // comparing exact ip?
+        if ($ip == $cidr) {
+            return true;
+        }
 
-		// validate ips and shorten them
+
+        if (strpos($cidr, '/') !== false) {
+            list($subnet, $mask) = explode('/', $cidr);
+        } else {
+            $subnet = $cidr;
+            $mask = 0;
+        }
+
+        // validate ips and shorten them
         if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
 
-			$ipVersion = 'v4';
-			// shorten ip
-			$ip = preg_replace( '/^(.*\.|.*:)?0+([1-9])/','$1$2',$ip );
+            $ipVersion = 'v4';
+            // shorten ip
+            $ip = preg_replace('/^(.*\.|.*:)?0+([1-9])/', '$1$2', $ip);
 
         } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
 
-			$ipVersion = 'v6';
-			// shorten ip
-			$ip = self::IPv6_compress($ip);
+            $ipVersion = 'v6';
+            // shorten ip
+            $ip = self::IPv6_compress($ip);
 
-		} else {
+        } else {
 
-			return false; // invalid ip
+            return false; // invalid ip
         }
 
-		// shorten cidr and subnet
-		if(strpos($subnet,':') === false)
-		{
-			$subnet = preg_replace( '/^(.*\.|.*:)?0+([1-9])/','$1$2',$subnet );
-		}
-		else
-		{
-			$pos = strpos($subnet,'*');
-			if($pos !== false)
-			{
-				$subnet = substr($subnet,0,$pos);
-				$i = 0;
-				$subnet = explode(':',$subnet);
-				$size = $j = sizeof($subnet);
-				while($j < 8){
-					$subnet[] = '0';
-					$j++;
-					$i++;
-				}
-				$subnet = implode(':',$subnet);
-				if(substr($subnet,-1) == ':'){
-					$subnet .= '0';
-				}
-			}
-			
-			$subnet = self::IPv6_compress($subnet);
-			
-			if($pos !== false)
-			{
-				$subnet = explode(':',$subnet);
-				$j = sizeof($subnet);
-				while($j > $size)
-				{
-					array_pop($subnet);
-					$j--;
-				}
-				$subnet = implode(':',$subnet).'*';
-			}
-		}
+        // shorten cidr and subnet
+        if (strpos($subnet, ':') === false) {
+            $subnet = preg_replace('/^(.*\.|.*:)?0+([1-9])/', '$1$2', $subnet);
+        } else {
+            $pos = strpos($subnet, '*');
+            if ($pos !== false) {
+                $subnet = substr($subnet, 0, $pos);
+                $i = 0;
+                $subnet = explode(':', $subnet);
+                $size = $j = sizeof($subnet);
+                while ($j < 8) {
+                    $subnet[] = '0';
+                    $j++;
+                    $i++;
+                }
+                $subnet = implode(':', $subnet);
+                if (substr($subnet, -1) == ':') {
+                    $subnet .= '0';
+                }
+            }
 
-		// shortened cidr
-		$cidr = ($mask ? $subnet.'/'.$mask : $subnet);
-		
-		// if $cidr is ipv6, convert $ip to ipv6 for easier comparison
-		if(strpos($subnet,':') !== false && $ipVersion == 'v4') {
-			
-			$v6bits = array('0000','0000','0000','0000','0000','0000',$ip);
-			
-			$ip4parts = explode('.', $v6bits[count($v6bits)-1]);
-			$ip6trans = sprintf("%02x%02x:%02x%02x", $ip4parts[0], $ip4parts[1], $ip4parts[2], $ip4parts[3]);
-			$v6bits[count($v6bits)-1] = $ip6trans;
+            $subnet = self::IPv6_compress($subnet);
 
-			$ip = implode(':', $v6bits);
-			// shorten ip
-			$ip = self::IPv6_compress($ip);
-			
-			$ipVersion = 'v6';
-		}
+            if ($pos !== false) {
+                $subnet = explode(':', $subnet);
+                $j = sizeof($subnet);
+                while ($j > $size) {
+                    array_pop($subnet);
+                    $j--;
+                }
+                $subnet = implode(':', $subnet).'*';
+            }
+        }
 
-		if($ip == $cidr)
-		{
-			return true;
-		}
+        // shortened cidr
+        $cidr = ($mask ? $subnet.'/'.$mask : $subnet);
 
-		// wildcard matching (easier since we already shortened or "canonicalized" ip and cidr above)
-		$pos = strpos($cidr,'*');
-		if($pos !== false)
-		{
-			if(substr($ip,0,$pos) == substr($cidr,0,$pos))
-			{
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
+        // if $cidr is ipv6, convert $ip to ipv6 for easier comparison
+        if (strpos($subnet, ':') !== false && $ipVersion == 'v4') {
 
-		 switch ($ipVersion) {
+            $v6bits = array('0000','0000','0000','0000','0000','0000',$ip);
+
+            $ip4parts = explode('.', $v6bits[count($v6bits) - 1]);
+            $ip6trans = sprintf("%02x%02x:%02x%02x", $ip4parts[0], $ip4parts[1], $ip4parts[2], $ip4parts[3]);
+            $v6bits[count($v6bits) - 1] = $ip6trans;
+
+            $ip = implode(':', $v6bits);
+            // shorten ip
+            $ip = self::IPv6_compress($ip);
+
+            $ipVersion = 'v6';
+        }
+
+        if ($ip == $cidr) {
+            return true;
+        }
+
+        // wildcard matching (easier since we already shortened or "canonicalized" ip and cidr above)
+        $pos = strpos($cidr, '*');
+        if ($pos !== false) {
+            if (substr($ip, 0, $pos) == substr($cidr, 0, $pos)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        switch ($ipVersion) {
             case 'v4':
-				return self::IPv4Match($ip, $subnet, $mask);
+                return self::IPv4Match($ip, $subnet, $mask);
                 break;
             case 'v6':
-				return self::IPv6Match($ip, $subnet, $mask);
+                return self::IPv6Match($ip, $subnet, $mask);
                 break;
         }
     }
 
 
 
-   /**
-	* Check IPv6 address is within an IP range
-	*
-	* @param  string  $address a valid IPv6 address
-	* @param  string  $subnet a valid IPv6 subnet
-	* @param  string  $mask a valid IPv6 subnet mask
-	* @return boolean	whether $address is within the ip range made up  of the subnet and mask
-	*/
+    /**
+     * Check IPv6 address is within an IP range
+     *
+     * @param  string  $address a valid IPv6 address
+     * @param  string  $subnet a valid IPv6 subnet
+     * @param  string  $mask a valid IPv6 subnet mask
+     * @return boolean	whether $address is within the ip range made up  of the subnet and mask
+     */
     private static function IPv6Match($ip, $subnet, $mask)
     {
         $subnet = inet_pton($subnet);
         $ip = inet_pton($ip);
 
-		// thanks to MW on http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
-		$binMask = str_repeat("f", $mask / 4);
+        // thanks to MW on http://stackoverflow.com/questions/7951061/matching-ipv6-address-to-a-cidr-subnet
+        $binMask = str_repeat("f", $mask / 4);
         switch ($mask % 4) {
             case 0:
                 break;
@@ -180,17 +173,17 @@ class CIDR{
         return ($ip & $binMask) == $subnet;
     }
 
-   /**
-	* Check IPv4 address is within an IP range
-	*
-	* @param  string  $address a valid IPv4 address
-	* @param  string  $subnet a valid IPv4 subnet
-	* @param  string  $mask a valid IPv4 subnet mask
-	* @return boolean	whether $address is within the ip rage made up  of the subnet and mask
-	*/
-	 private static function IPv4Match($address, $subnet, $mask)
+    /**
+     * Check IPv4 address is within an IP range
+     *
+     * @param  string  $address a valid IPv4 address
+     * @param  string  $subnet a valid IPv4 subnet
+     * @param  string  $mask a valid IPv4 subnet mask
+     * @return boolean	whether $address is within the ip rage made up  of the subnet and mask
+     */
+    private static function IPv4Match($address, $subnet, $mask)
     {
-		// credit goes to Sam on http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5
+        // credit goes to Sam on http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5
         if ((ip2long($address) & ~((1 << (32 - $mask)) - 1)) == ip2long($subnet)) {
             return true;
         }
@@ -198,60 +191,63 @@ class CIDR{
         return false;
     }
 
-	/**
-	* Compress an IPv6 Address
-	*
-	* @param  string  $ip a valid IPv6 address or CIDR
-	* @return string  IPv6 ip address or CIDR in short form notation
-	*/
-	public static function IPv6_compress($ip)
-	{
-		$bits = explode('/',$ip); // in case this is a CIDR range
-		
-		// want to expand and re-compress in case we have "::" in different spots.
-		$bits[0] = self::IPv6_expand($bits[0]);
+    /**
+    * Compress an IPv6 Address
+    *
+    * @param  string  $ip a valid IPv6 address or CIDR
+    * @return string  IPv6 ip address or CIDR in short form notation
+    */
+    public static function IPv6_compress($ip)
+    {
+        $bits = explode('/', $ip); // in case this is a CIDR range
 
-		$bits[0] = inet_ntop(inet_pton($bits[0]));
-		return strtolower(implode('/',$bits));
-	}
+        // want to expand and re-compress in case we have "::" in different spots.
+        $bits[0] = self::IPv6_expand($bits[0]);
 
-	/**
-	* Expand an IPv6 Address
-	*
-	* @param  string  $ip a valid IPv6 address
-	* @return string  IPv6 ip address in long form notation
-	*/
-	public static function IPv6_expand($ip){
-		
-		$bits = explode('/',$ip); // in case this is a CIDR range
-		
-		// add missing components
-		if (strpos($bits[0], '::') !== false) {
-			$part = explode('::', $bits[0]);
-			$part[0] = explode(':', $part[0]);
-			$part[1] = explode(':', $part[1]);
-			$missing = array();
-			for ($i = 0; $i < (8 - (count($part[0]) + count($part[1]))); $i++)
-				array_push($missing, '0000');
-			$missing = array_merge($part[0], $missing);
-			$part = array_merge($missing, $part[1]);
-		} else {
-			$part = explode(":", $bits[0]);
-		}
-		
-		// Pad components to 4 characters
-		foreach ($part as &$p) {
-			while (strlen($p) < 4) $p = '0' . $p;
-		}
-		unset($p);
+        $bits[0] = inet_ntop(inet_pton($bits[0]));
+        return strtolower(implode('/', $bits));
+    }
 
-		$bits[0] = implode(':', $part);
+    /**
+    * Expand an IPv6 Address
+    *
+    * @param  string  $ip a valid IPv6 address
+    * @return string  IPv6 ip address in long form notation
+    */
+    public static function IPv6_expand($ip)
+    {
 
-		// if it is the incorrect length, something went wrong.
-		if (strlen($bits[0]) != 39) {
-			return false;
-		}
-		return strtolower(implode('/',$bits));
-	}
+        $bits = explode('/', $ip); // in case this is a CIDR range
+
+        // add missing components
+        if (strpos($bits[0], '::') !== false) {
+            $part = explode('::', $bits[0]);
+            $part[0] = explode(':', $part[0]);
+            $part[1] = explode(':', $part[1]);
+            $missing = array();
+            for ($i = 0; $i < (8 - (count($part[0]) + count($part[1]))); $i++) {
+                array_push($missing, '0000');
+            }
+            $missing = array_merge($part[0], $missing);
+            $part = array_merge($missing, $part[1]);
+        } else {
+            $part = explode(":", $bits[0]);
+        }
+
+        // Pad components to 4 characters
+        foreach ($part as &$p) {
+            while (strlen($p) < 4) {
+                $p = '0' . $p;
+            }
+        }
+        unset($p);
+
+        $bits[0] = implode(':', $part);
+
+        // if it is the incorrect length, something went wrong.
+        if (strlen($bits[0]) != 39) {
+            return false;
+        }
+        return strtolower(implode('/', $bits));
+    }
 }
-?>

--- a/PHPGangsta/GoogleAuthenticator.php
+++ b/PHPGangsta/GoogleAuthenticator.php
@@ -74,9 +74,12 @@ class PHPGangsta_GoogleAuthenticator
      * @param string $title
      * @return string
      */
-    public function getQRCodeGoogleUrl($name, $secret, $title=null) {
+    public function getQRCodeGoogleUrl($name, $secret, $title = null)
+    {
         $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
-	if(isset($title)) $urlencoded .= urlencode('&issuer='.$title);
+        if (isset($title)) {
+            $urlencoded .= urlencode('&issuer='.$title);
+        }
         return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='.$urlencoded.'';
     }
 
@@ -94,7 +97,7 @@ class PHPGangsta_GoogleAuthenticator
 
         for ($i = -$discrepancy; $i <= $discrepancy; $i++) {
             $calculatedCode = $this->getCode($secret, $currentTimeSlice + $i);
-            if ($calculatedCode == $code ) {
+            if ($calculatedCode == $code) {
                 return true;
             }
         }
@@ -122,30 +125,38 @@ class PHPGangsta_GoogleAuthenticator
      */
     protected function _base32Decode($secret)
     {
-        if (empty($secret)) return '';
+        if (empty($secret)) {
+            return '';
+        }
 
         $base32chars = $this->_getBase32LookupTable();
         $base32charsFlipped = array_flip($base32chars);
 
         $paddingCharCount = substr_count($secret, $base32chars[32]);
         $allowedValues = array(6, 4, 3, 1, 0);
-        if (!in_array($paddingCharCount, $allowedValues)) return false;
-        for ($i = 0; $i < 4; $i++){
-            if ($paddingCharCount == $allowedValues[$i] &&
-                substr($secret, -($allowedValues[$i])) != str_repeat($base32chars[32], $allowedValues[$i])) return false;
+        if (!in_array($paddingCharCount, $allowedValues)) {
+            return false;
         }
-        $secret = str_replace('=','', $secret);
+        for ($i = 0; $i < 4; $i++) {
+            if ($paddingCharCount == $allowedValues[$i] &&
+                substr($secret, -($allowedValues[$i])) != str_repeat($base32chars[32], $allowedValues[$i])) {
+                return false;
+            }
+        }
+        $secret = str_replace('=', '', $secret);
         $secret = str_split($secret);
         $binaryString = "";
-        for ($i = 0; $i < count($secret); $i = $i+8) {
+        for ($i = 0; $i < count($secret); $i = $i + 8) {
             $x = "";
-            if (!in_array($secret[$i], $base32chars)) return false;
+            if (!in_array($secret[$i], $base32chars)) {
+                return false;
+            }
             for ($j = 0; $j < 8; $j++) {
                 $x .= str_pad(base_convert(@$base32charsFlipped[@$secret[$i + $j]], 10, 2), 5, '0', STR_PAD_LEFT);
             }
             $eightBits = str_split($x, 8);
             for ($z = 0; $z < count($eightBits); $z++) {
-                $binaryString .= ( ($y = chr(base_convert($eightBits[$z], 2, 10))) || ord($y) == 48 ) ? $y:"";
+                $binaryString .= (($y = chr(base_convert($eightBits[$z], 2, 10))) || ord($y) == 48) ? $y : "";
             }
         }
         return $binaryString;
@@ -160,7 +171,9 @@ class PHPGangsta_GoogleAuthenticator
      */
     protected function _base32Encode($secret, $padding = true)
     {
-        if (empty($secret)) return '';
+        if (empty($secret)) {
+            return '';
+        }
 
         $base32chars = $this->_getBase32LookupTable();
 
@@ -177,10 +190,15 @@ class PHPGangsta_GoogleAuthenticator
             $i++;
         }
         if ($padding && ($x = strlen($binaryString) % 40) != 0) {
-            if ($x == 8) $base32 .= str_repeat($base32chars[32], 6);
-            elseif ($x == 16) $base32 .= str_repeat($base32chars[32], 4);
-            elseif ($x == 24) $base32 .= str_repeat($base32chars[32], 3);
-            elseif ($x == 32) $base32 .= $base32chars[32];
+            if ($x == 8) {
+                $base32 .= str_repeat($base32chars[32], 6);
+            } elseif ($x == 16) {
+                $base32 .= str_repeat($base32chars[32], 4);
+            } elseif ($x == 24) {
+                $base32 .= str_repeat($base32chars[32], 3);
+            } elseif ($x == 32) {
+                $base32 .= $base32chars[32];
+            }
         }
         return $base32;
     }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Two-factor verification
-=======================
+# Two-factor verification
 
 This RoundCube plugin adds the 2-step verification (OTP) to the login proccess.
 
@@ -10,28 +9,26 @@ Some code by:
 - [Ricardo Signes](https://github.com/rjbs)
 - [Justin Buchanan](https://github.com/jusbuc2k)
 - [Ricardo Iván Vieitez Parra](https://github.com/corrideat)
-- [GoogleAuthenticator class](https://github.com/PHPGangsta/GoogleAuthenticator/) by Michael Kliewe (to *see* secrets)
+- [GoogleAuthenticator class](https://github.com/PHPGangsta/GoogleAuthenticator/) by Michael Kliewe (to _see_ secrets)
 - [qrcode.js](https://github.com/davidshimjs/qrcodejs) by ShimSangmin
-- Also thx to [Victor R. Rodriguez Dominguez](https://github.com/vrdominguez) for some ideas and support  
+- Also thx to [Victor R. Rodriguez Dominguez](https://github.com/vrdominguez) for some ideas and support
 
 ![Login](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/001-login.png)
 ![2Steps](https://raw.github.com/alexandregz/twofactor_gauthenticator/master/screenshots/002-2steps.png)
 
-
-Installation
-------------
+## Installation
 
 - Clone from GitHub inside the plugins directory of Roundcube:
+
   1. `cd plugins`
   2. `git clone https://github.com/alexandregz/twofactor_gauthenticator.git`
-
 
 - Or use composer from the Roundcube root directory:
 
   ```sh
   composer require alexandregz/twofactor_gauthenticator:dev-master
   ```
-     
+
   _NOTE:_ Answer **N** when composer ask you about plugin activation.
 
 - Activate the plugin by editing the `HOME_RC/config/config.inc.php` file:
@@ -42,8 +39,7 @@ Installation
   ];
   ```
 
-Configuration
--------------
+## Configuration
 
 Copy `HOME_RC/plugins/twofactor_gauthenticator/config.inc.php.dist` to `HOME_RC/plugins/twofactor_gauthenticator/config.inc.php`.
 
@@ -53,9 +49,8 @@ NOTE: plugin must be base32 valid characters ([A-Z][2-7]), see https://github.co
 
 From https://github.com/alexandregz/twofactor_gauthenticator/issues/139
 
+## Usage
 
-Usage
-----------------
 The first time you open the app you see the default settings:
 
 ![Default Settings](https://github.com/user-attachments/assets/deb6718d-e2e0-4615-bf54-77f1207698d1)
@@ -64,7 +59,7 @@ The most easy way to configure the app is by clicking "Fill all fields". The plu
 
 ![Untitled](https://github.com/user-attachments/assets/e8f0582a-66f7-435b-a2d2-bac94cfd5acd)
 
-Now scan the QR code with any authenticator app, generate a code, enter your new code in the bottom field and press "Check code". If your code is a match, you can press "Save" to save the configuration. 
+Now scan the QR code with any authenticator app, generate a code, enter your new code in the bottom field and press "Check code". If your code is a match, you can press "Save" to save the configuration.
 
 Alternatively, you can configure the app manually by checking the checkbox and pressing "Save". A secret will be automatically generated:
 
@@ -76,83 +71,80 @@ Also, you can add "Recovery codes" for use one time (they are deleted when used)
 
 ![Recovery codes](https://github.com/user-attachments/assets/dedba088-50c6-423d-8ed8-a1137c37d41d)
 
+## Enrollment Users
 
-Enrollment Users
-----------------
+If config value _force_enrollment_users_ is true, **ALL** users needs to login with 2-step method. They receive alert message about that, and they can't skip without save configuration
 
-If config value *force_enrollment_users* is true, **ALL** users needs to login with 2-step method. They receive alert message about that, and they can't skip without save configuration
+## Samefield
 
-
-Samefield
----------
-
-If config value *2step_codes_on_login_form* is true, 2-step codes (and recovery) must be sended with password value, append to this, from the login screen: "Normal" codes just following password (passswordCODE), recovery codes after two pipes (passsword||RECOVERYCODE)
+If config value _2step_codes_on_login_form_ is true, 2-step codes (and recovery) must be sended with password value, append to this, from the login screen: "Normal" codes just following password (passswordCODE), recovery codes after two pipes (passsword||RECOVERYCODE)
 
 Actually only into samefield branch
 
-Codes
------
+## Codes
 
-Codes have a 2*30 seconds clock tolerance, like by default with Google app (Maybe editable in future versions)
+Codes have a 2\*30 seconds clock tolerance, like by default with Google app (Maybe editable in future versions)
 
-License
--------
+## Code formatting
+
+Install PHP-CS-Fixer (requires `composer` to be installed):
+
+```sh
+composer install --working-dir=./tools/php-cs-fixer
+```
+
+Run the coding standards fixer:
+
+```sh
+./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix twofactor_gauthenticator.php
+```
+
+## License
 
 MIT, see License
 
-Notes
------
+## Notes
 
 Tested with RoundCube 0.9.5 and Google app. Also with Roundcube 1.0.4 and 1.6.9 with OpenAuthenticator.
 
 Remember, sync time it's essential for TOTP: "For this to work, the clocks of the user's device and the server need to be roughly synchronized (the server will typically accept one-time passwords generated from timestamps that differ by ±1 from the client's timestamp)" (from http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm)
 
-Author
-------
+## Author
 
 Alexandre Espinosa Menor <aemenor@gmail.com>
 
-Issues
-------
+## Issues
 
 Open issues using github, don't send me emails about that, please -usually Gmail marks messages like SPAM
 
-Testing
--------
+## Testing
 
 - Vagrant: https://github.com/alexandregz/vagrant-twofactor_gauthenticator
 - Docker: https://hub.docker.com/r/alexandregz/twofactor_gauthenticator/
 
-Using with Kolab
-----------------
+## Using with Kolab
 
 Add a symlink into the public_html/assets directory
 
 Show explained https://github.com/alexandregz/twofactor_gauthenticator/issues/29#issuecomment-156838186 by https://github.com/d7415
 
-Client implementations
-----------------------
+## Client implementations
 
 You can use various [OTP clients](https://en.wikipedia.org/wiki/HMAC-based_One-time_Password_Algorithm#Applications) -link by https://github.com/helmo
 
-Logs
-----
+## Logs
 
 Suggested by simon@magrin.com
 
-To log errors with bad codes, change the $_enable_logs variable to true.
+To log errors with bad codes, change the $\_enable_logs variable to true.
 
 The logs are stored to the file HOME_RC/logs/log_errors_2FA.txt -directory must be created
 
-
-Whitelist
----------
+## Whitelist
 
 You can define whitelist IPs into config file (see config.inc.php.dist) to automatic login -the plugin don't ask you for code
 
-
-Uninstall
----------
+## Uninstall
 
 To deactivate the plugin, you can use two methods:
 
@@ -160,27 +152,23 @@ To deactivate the plugin, you can use two methods:
 
 - To all: remove the plugin from config.inc.php/remove the plugin itself
 
-
-Activate only for specific users
---------------------------------
+## Activate only for specific users
 
 - Use config.inc.php file (see config.inc.php.dist example file)
 
-- Modify array  **users_allowed_2FA** with users that you want to use plugin. NOTE: you can use regular expressions
-
+- Modify array **users_allowed_2FA** with users that you want to use plugin. NOTE: you can use regular expressions
 
 ## Use with 1.3.x version
 
-Use *1.3.9-version* branch
+Use _1.3.9-version_ branch
 
 `$ git checkout 1.3.9-version`
 
-If you download 1.4.x RC version (with *elastic skin*), use *master* version normally (thx to [tborgans](https://github.com/tborgans))
+If you download 1.4.x RC version (with _elastic skin_), use _master_ version normally (thx to [tborgans](https://github.com/tborgans))
 
 ![Elastic Skin start](https://raw.githubusercontent.com/alexandregz/twofactor_gauthenticator/master/screenshots/009-elastic_skin_start.png)
 
 ![Elastic Skin config](https://raw.githubusercontent.com/alexandregz/twofactor_gauthenticator/master/screenshots/010-elastic_skin_config.png)
-
 
 ## Security incident 2022-04-02
 
@@ -190,14 +178,13 @@ I made a little modification on script to not allow to save config without param
 
 NOTE: Also I check if user have 2FA activated because with only first condition -check SESSION- app kick out me before to activate 2FA.
 
-
 #### `twofactor_gauthenticator_save()`
 
 On function `twofactor_gauthenticator_save()` I added this code:
 
 ```php
     // save config
-    function twofactor_gauthenticator_save() 
+    function twofactor_gauthenticator_save()
     {
         $rcmail = rcmail::get_instance();
 
@@ -211,9 +198,7 @@ On function `twofactor_gauthenticator_save()` I added this code:
 		}
 ```
 
-
 The idea is to create a session variable from a rendered page, redirected from `__goingRoundcubeTask` function (redirector to `roundcube tasks`)
-
 
 #### tests with PoC python script
 
@@ -229,7 +214,7 @@ Password:xxxxxxxx
   POST http://localhost:8888/roundcubemail-1.4.8/?_task=settings&_action=plugin.twofactor_gauthenticator-save
   POST returned task "settings"
 2FA disabled!
-``` 
+```
 
 Modified code and tested again, not allowed to deactivated/modified without going to a RC task (with 2FA authentication):
 
@@ -243,7 +228,7 @@ Password:xxxxxxxxx
   POST http://localhost:8888/roundcubemail-1.4.8/?_task=settings&_action=plugin.twofactor_gauthenticator-save
   POST returned task "login"
 Expected "settings" task, something went wrong
-``` 
+```
 
 ## docker-compose
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Install PHP-CS-Fixer (requires `composer` to be installed):
 composer install --working-dir=./tools/php-cs-fixer
 ```
 
-Run the coding standards fixer:
+Run the coding standards fixer (in current working directory):
 
 ```sh
-./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix twofactor_gauthenticator.php
+./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix .
 ```
 
 ## License

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -14,10 +14,8 @@ $rcmail_config['allow_save_device_30days'] = true;
 // Default: form field will be text (false)
 $rcmail_config['twofactor_formfield_as_password'] = false;
 
-
 // Users allowed to use plugin (IMPORTANT: other users DON'T have plugin activated). Regex is supported.
 $rcmail_config['users_allowed_2FA'] = array('ale.*@tereborace.com', 'administrator@tereborace.com');
-
 
 // failure logging, suggested by @pngd (issue 131)
 $rcmail_config['enable_fail_logs'] = false;

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -15,7 +15,7 @@ $rcmail_config['allow_save_device_30days'] = true;
 $rcmail_config['twofactor_formfield_as_password'] = false;
 
 
-// Users allowed to use plugin (IMPORTANT: other users DON'T have plugin activated)
+// Users allowed to use plugin (IMPORTANT: other users DON'T have plugin activated). Regex is supported.
 $rcmail_config['users_allowed_2FA'] = array('ale.*@tereborace.com', 'administrator@tereborace.com');
 
 

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.66"
+    }
+}

--- a/tools/php-cs-fixer/composer.lock
+++ b/tools/php-cs-fixer/composer.lock
@@ -1,0 +1,2546 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "9131aecc3e9e289971db008b5d121b81",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "clue/ndjson-react",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-ndjson.git",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-ndjson/zipball/392dc165fce93b5bb5c637b67e59619223c931b0",
+                "reference": "392dc165fce93b5bb5c637b67e59619223c931b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/stream": "^1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+                "react/event-loop": "^1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\NDJson\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Streaming newline-delimited JSON (NDJSON) parser and encoder for ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-ndjson",
+            "keywords": [
+                "NDJSON",
+                "json",
+                "jsonlines",
+                "newline",
+                "reactphp",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-ndjson/issues",
+                "source": "https://github.com/clue/reactphp-ndjson/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-23T10:58:28+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T14:15:21+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
+                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0.0",
+                "phpstan/phpstan-phpunit": "^1.2.2",
+                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-06T10:04:20+00:00"
+        },
+        {
+            "name": "friendsofphp/php-cs-fixer",
+            "version": "v3.66.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
+                "reference": "5f5f2a142ff36b93c41885bca29cc5f861c013e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/5f5f2a142ff36b93c41885bca29cc5f861c013e6",
+                "reference": "5f5f2a142ff36b93c41885bca29cc5f861c013e6",
+                "shasum": ""
+            },
+            "require": {
+                "clue/ndjson-react": "^1.0",
+                "composer/semver": "^3.4",
+                "composer/xdebug-handler": "^3.0.3",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "fidry/cpu-core-counter": "^1.2",
+                "php": "^7.4 || ^8.0",
+                "react/child-process": "^0.6.5",
+                "react/event-loop": "^1.0",
+                "react/promise": "^2.0 || ^3.0",
+                "react/socket": "^1.0",
+                "react/stream": "^1.0",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.28",
+                "symfony/polyfill-php80": "^1.28",
+                "symfony/polyfill-php81": "^1.28",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0 <7.2",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "facile-it/paraunit": "^1.3.1 || ^2.4",
+                "infection/infection": "^0.29.8",
+                "justinrainbow/json-schema": "^5.3 || ^6.0",
+                "keradus/cli-executor": "^2.1",
+                "mikey179/vfsstream": "^1.6.12",
+                "php-coveralls/php-coveralls": "^2.7",
+                "php-cs-fixer/accessible-object": "^1.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.5",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.5",
+                "phpunit/phpunit": "^9.6.21 || ^10.5.38 || ^11.4.3",
+                "symfony/var-dumper": "^5.4.47 || ^6.4.15 || ^7.1.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.13 || ^7.1.6"
+            },
+            "suggest": {
+                "ext-dom": "For handling output formats in XML",
+                "ext-mbstring": "For handling non-UTF8 characters."
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixer\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Fixer/Internal/*"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.66.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-12-29T13:46:23+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/child-process",
+            "version": "v0.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/child-process.git",
+                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/1721e2b93d89b745664353b9cfc8f155ba8a6159",
+                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/event-loop": "^1.2",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/socket": "^1.16",
+                "sebastian/environment": "^5.0 || ^3.0 || ^2.0 || ^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\ChildProcess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven library for executing child processes with ReactPHP.",
+            "keywords": [
+                "event-driven",
+                "process",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/child-process/issues",
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.6"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-01-01T16:37:48+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-13T14:18:03+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-11-13T13:48:05+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-24T10:39:05+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-07-26T10:38:09+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-11T03:49:26+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-10-25T15:15:23+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
+                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-30T19:00:17+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-20T11:17:29+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "42783370fda6e538771f7c7a36e9fa2ee3a84892"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/42783370fda6e538771f7c7a36e9fa2ee3a84892",
+                "reference": "42783370fda6e538771f7c7a36e9fa2ee3a84892",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T14:23:19+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e46690d5b9d7164a6d061cab1e8d46141b9f49df",
+                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-18T14:28:33+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-13T13:31:26+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -1,9 +1,10 @@
 <?php
+
 /**
  * Two-factor Google Authenticator for RoundCube
- * 
+ *
  * This RoundCube plugin adds the 2-step verification(OTP) to the login proccess
- * 
+ *
  * @version 2.0.0
  * @author Alexandre Espinosa <aemenor@gmail.com>
  *
@@ -15,97 +16,96 @@ require_once 'PHPGangsta/GoogleAuthenticator.php';
 
 require_once 'CIDR.php';
 
-class twofactor_gauthenticator extends rcube_plugin 
+class twofactor_gauthenticator extends rcube_plugin
 {
-	private $_number_recovery_codes = 4;
+    private $_number_recovery_codes = 4;
 
-        // relative to $config['log_dir']
-        private $_logs_file = 'log_errors_2FA.txt';
-	
-    function init() 
+    // relative to $config['log_dir']
+    private $_logs_file = 'log_errors_2FA.txt';
+
+    public function init()
     {
-		$rcmail = rcmail::get_instance();
-    	    	 
-		// hooks
-    	$this->add_hook('login_after', array($this, 'login_after'));
-    	$this->add_hook('send_page', array($this, 'check_2FAlogin'));
-    	$this->add_hook('render_page', array($this, 'popup_msg_enrollment'));
-    	    	 
-    	$this->load_config();
-		
-		$allowedPlugin = $this->__pluginAllowedByConfig();
-			
-		// skipping all logic and plugin not appears
-		if(!$allowedPlugin) {
-			return false;
-		}		
-    	 
-		$this->add_texts('localization/', true);
-		
-		// check code with ajax
-		$this->register_action('plugin.twofactor_gauthenticator-checkcode', array($this, 'checkCode'));
+        $rcmail = rcmail::get_instance();
 
-		// config
-		$this->register_action('twofactor_gauthenticator', array($this, 'twofactor_gauthenticator_init'));
-		$this->register_action('plugin.twofactor_gauthenticator-save', array($this, 'twofactor_gauthenticator_save'));
-		$this->include_script('twofactor_gauthenticator.js');
-		$this->include_script('qrcode.min.js');
-		
-		// settings we will export to the form javascript
-		//$this_output = $this->api->output;
-		//if ($this_output) {
-		//	$this->api->output->set_env('allow_save_device_30days',$rcmail->config->get('allow_save_device_30days',true));
-		//	$this->api->output->set_env('twofactor_formfield_as_password',$rcmail->config->get('twofactor_formfield_as_password',false));
-		//}
+        // hooks
+        $this->add_hook('login_after', array($this, 'login_after'));
+        $this->add_hook('send_page', array($this, 'check_2FAlogin'));
+        $this->add_hook('render_page', array($this, 'popup_msg_enrollment'));
+
+        $this->load_config();
+
+        $allowedPlugin = $this->__pluginAllowedByConfig();
+
+        // skipping all logic and plugin not appears
+        if (!$allowedPlugin) {
+            return false;
+        }
+
+        $this->add_texts('localization/', true);
+
+        // check code with ajax
+        $this->register_action('plugin.twofactor_gauthenticator-checkcode', array($this, 'checkCode'));
+
+        // config
+        $this->register_action('twofactor_gauthenticator', array($this, 'twofactor_gauthenticator_init'));
+        $this->register_action('plugin.twofactor_gauthenticator-save', array($this, 'twofactor_gauthenticator_save'));
+        $this->include_script('twofactor_gauthenticator.js');
+        $this->include_script('qrcode.min.js');
+
+        // settings we will export to the form javascript
+        //$this_output = $this->api->output;
+        //if ($this_output) {
+        //	$this->api->output->set_env('allow_save_device_30days',$rcmail->config->get('allow_save_device_30days',true));
+        //	$this->api->output->set_env('twofactor_formfield_as_password',$rcmail->config->get('twofactor_formfield_as_password',false));
+        //}
     }
-	
-	// check if user are valid from config.inc.php or true (by default) if config.inc.php not exists
-	function __pluginAllowedByConfig() {
-		$rcmail = rcmail::get_instance();
-    	    	 
-		$this->load_config();
 
-		// users allowed to use plugin (not showed for others!).
-		//	-- From config.inc.php file.
-		//  -- You can use regexp: admin.*@domain.com
-		$users = $rcmail->config->get('users_allowed_2FA');
-		if(is_array($users)) {		// exists "users" from config.inc.php
-			foreach($users as $u) {
-				if (isset( $rcmail->user->data['username'])){
-					preg_match("/$u/", $rcmail->user->data['username'], $matches);
-
-					if(isset($matches[0])) {
-						return true;
-					}
-				}	
-			}
-
-			// not allowed for all, except explicit
-			return false;
-		}
-
-		// by default, all users have plugin activated
-		return true;
-	}
-
-    
-    // Use the form login, but removing inputs with jquery and action (see twofactor_gauthenticator_form.js)
-    function login_after($args)
+    // check if user are valid from config.inc.php or true (by default) if config.inc.php not exists
+    public function __pluginAllowedByConfig()
     {
-		$_SESSION['twofactor_gauthenticator_login'] = time();
-		
-		$rcmail = rcmail::get_instance();
-		
-		
-		$config_2FA = self::__get2FAconfig();
-		if(!($config_2FA['activate'] ?? false))
-		{
-			if($rcmail->config->get('force_enrollment_users'))
-			{
-				$this->__goingRoundcubeTask('settings', 'plugin.twofactor_gauthenticator');				
-			}
-			return;
-		}
+        $rcmail = rcmail::get_instance();
+
+        $this->load_config();
+
+        // users allowed to use plugin (not showed for others!).
+        //	-- From config.inc.php file.
+        //  -- You can use regexp: admin.*@domain.com
+        $users = $rcmail->config->get('users_allowed_2FA');
+        if (is_array($users)) {		// exists "users" from config.inc.php
+            foreach ($users as $u) {
+                if (isset($rcmail->user->data['username'])) {
+                    preg_match("/$u/", $rcmail->user->data['username'], $matches);
+
+                    if (isset($matches[0])) {
+                        return true;
+                    }
+                }
+            }
+
+            // not allowed for all, except explicit
+            return false;
+        }
+
+        // by default, all users have plugin activated
+        return true;
+    }
+
+
+    // Use the form login, but removing inputs with jquery and action (see twofactor_gauthenticator_form.js)
+    public function login_after($args)
+    {
+        $_SESSION['twofactor_gauthenticator_login'] = time();
+
+        $rcmail = rcmail::get_instance();
+
+
+        $config_2FA = self::__get2FAconfig();
+        if (!($config_2FA['activate'] ?? false)) {
+            if ($rcmail->config->get('force_enrollment_users')) {
+                $this->__goingRoundcubeTask('settings', 'plugin.twofactor_gauthenticator');
+            }
+            return;
+        }
 
         if ($this->__cookie($set = false) || !$this->__pluginAllowedByConfig()) {
             $_SESSION['twofactor_gauthenticator_login'] -= 1; // so that we may use ge to check for valid session
@@ -113,180 +113,174 @@ class twofactor_gauthenticator extends rcube_plugin
             return;
         }
 
-		$rcmail->output->set_pagetitle($this->gettext('twofactor_gauthenticator'));
+        $rcmail->output->set_pagetitle($this->gettext('twofactor_gauthenticator'));
 
-                $rcmail->output->set_env('allow_save_device_30days',$rcmail->config->get('allow_save_device_30days',true));
-                $rcmail->output->set_env('twofactor_formfield_as_password',$rcmail->config->get('twofactor_formfield_as_password',false));
+        $rcmail->output->set_env('allow_save_device_30days', $rcmail->config->get('allow_save_device_30days', true));
+        $rcmail->output->set_env('twofactor_formfield_as_password', $rcmail->config->get('twofactor_formfield_as_password', false));
 
-		$this->add_texts('localization', true);
-		$this->include_script('twofactor_gauthenticator_form.js');
-    	
-    	$rcmail->output->send('login');
+        $this->add_texts('localization', true);
+        $this->include_script('twofactor_gauthenticator_form.js');
+
+        $rcmail->output->send('login');
     }
-    
-	// capture webpage if someone try to use ?_task=mail|addressbook|settings|... and check auth code
-	function check_2FAlogin($p)
-	{
-		$rcmail = rcmail::get_instance();
-		$config_2FA = self::__get2FAconfig();
 
-		if($config_2FA['activate'] ?? false)
-		{
-			// with IP allowed, we don't need to check anything
-			if($rcmail->config->get('whitelist')) {
-				foreach($rcmail->config->get('whitelist') as $ip_to_check) {
-					if (isset($_SERVER['HTTP_CLIENT_IP']) && array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
-						$realip = $_SERVER['HTTP_CLIENT_IP'];
-					} elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
-						$realips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
-						$realips = array_map('trim', $realips);
-						$realip = $realips[0];
-					} else {
-						$realip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
-					}
-					if(CIDR::match($realip, $ip_to_check)) {
-						if(isset($_SESSION['twofactor_gauthenticator_login'])) {
-							if($rcmail->task === 'login') $this->__goingRoundcubeTask('mail');
-							return $p;
-						}
-                                        }
-                                }
-                        }
-
-
-			$code = rcube_utils::get_input_value('_code_2FA', rcube_utils::INPUT_POST);
-			$remember = rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST);
-
-			if($code)
-			{
-				if(self::__checkCode($code) || self::__isRecoveryCode($code))
-				{
-					if(self::__isRecoveryCode($code))
-					{
-						self::__consumeRecoveryCode($code);
-					}
-
-                                        if (rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST) === 'yes') {
-                                            $this->__cookie($set = true);
-                                        }
-
-					$this->__goingRoundcubeTask('mail');
-				}
-				else
-				{
-                                        if($rcmail->config->get('enable_fail_logs')) {
-                                                $this->__logError();
-                                        }
-					$this->__exitSession();
-				}
-			}
-			// we're into some task but marked with login...
-			elseif($rcmail->task !== 'login' && ! $_SESSION['twofactor_gauthenticator_2FA_login'] >= $_SESSION['twofactor_gauthenticator_login'])
-			{
-				$this->__exitSession();
-			}
-			
-		}
-		elseif($rcmail->config->get('force_enrollment_users') && ($rcmail->task !== 'settings' || $rcmail->action !== 'plugin.twofactor_gauthenticator'))	
-		{
-			if($rcmail->task !== 'login')	// resolve some redirection loop with logout
-			{
-				$this->__goingRoundcubeTask('settings', 'plugin.twofactor_gauthenticator');
-			}
-		}
-
-		return $p;
-	}
-	
-	
-	// ripped from new_user_dialog plugin
-	function popup_msg_enrollment()
-	{
-		$rcmail = rcmail::get_instance();
-		$config_2FA = self::__get2FAconfig();
-		
-		if(!($config_2FA['activate'] ?? false)
-			&& $rcmail->config->get('force_enrollment_users') && $rcmail->task == 'settings' && $rcmail->action == 'plugin.twofactor_gauthenticator')
-		{
-			// add overlay input box to html page
-			$rcmail->output->add_footer(html::tag('form', array(
-					'id' => 'enrollment_dialog',
-					'method' => 'post'),
-					html::tag('h3', null, $this->gettext('enrollment_dialog_title')) .
-					$this->gettext('enrollment_dialog_msg')
-			));
-
-			$rcmail->output->add_script(
-					"$('#enrollment_dialog').show().dialog({ modal:true, resizable:false, closeOnEscape: true, width:420 });", 'docready'
-			);
-		}		
-	}
-	
-
-	// show config
-    function twofactor_gauthenticator_init() 
+    // capture webpage if someone try to use ?_task=mail|addressbook|settings|... and check auth code
+    public function check_2FAlogin($p)
     {
         $rcmail = rcmail::get_instance();
-       
+        $config_2FA = self::__get2FAconfig();
+
+        if ($config_2FA['activate'] ?? false) {
+            // with IP allowed, we don't need to check anything
+            if ($rcmail->config->get('whitelist')) {
+                foreach ($rcmail->config->get('whitelist') as $ip_to_check) {
+                    if (isset($_SERVER['HTTP_CLIENT_IP']) && array_key_exists('HTTP_CLIENT_IP', $_SERVER)) {
+                        $realip = $_SERVER['HTTP_CLIENT_IP'];
+                    } elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && array_key_exists('HTTP_X_FORWARDED_FOR', $_SERVER)) {
+                        $realips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+                        $realips = array_map('trim', $realips);
+                        $realip = $realips[0];
+                    } else {
+                        $realip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+                    }
+                    if (CIDR::match($realip, $ip_to_check)) {
+                        if (isset($_SESSION['twofactor_gauthenticator_login'])) {
+                            if ($rcmail->task === 'login') {
+                                $this->__goingRoundcubeTask('mail');
+                            }
+                            return $p;
+                        }
+                    }
+                }
+            }
+
+
+            $code = rcube_utils::get_input_value('_code_2FA', rcube_utils::INPUT_POST);
+            $remember = rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST);
+
+            if ($code) {
+                if (self::__checkCode($code) || self::__isRecoveryCode($code)) {
+                    if (self::__isRecoveryCode($code)) {
+                        self::__consumeRecoveryCode($code);
+                    }
+
+                    if (rcube_utils::get_input_value('_remember_2FA', rcube_utils::INPUT_POST) === 'yes') {
+                        $this->__cookie($set = true);
+                    }
+
+                    $this->__goingRoundcubeTask('mail');
+                } else {
+                    if ($rcmail->config->get('enable_fail_logs')) {
+                        $this->__logError();
+                    }
+                    $this->__exitSession();
+                }
+            }
+            // we're into some task but marked with login...
+            elseif ($rcmail->task !== 'login' && ! $_SESSION['twofactor_gauthenticator_2FA_login'] >= $_SESSION['twofactor_gauthenticator_login']) {
+                $this->__exitSession();
+            }
+
+        } elseif ($rcmail->config->get('force_enrollment_users') && ($rcmail->task !== 'settings' || $rcmail->action !== 'plugin.twofactor_gauthenticator')) {
+            if ($rcmail->task !== 'login') {	// resolve some redirection loop with logout
+                $this->__goingRoundcubeTask('settings', 'plugin.twofactor_gauthenticator');
+            }
+        }
+
+        return $p;
+    }
+
+
+    // ripped from new_user_dialog plugin
+    public function popup_msg_enrollment()
+    {
+        $rcmail = rcmail::get_instance();
+        $config_2FA = self::__get2FAconfig();
+
+        if (!($config_2FA['activate'] ?? false)
+            && $rcmail->config->get('force_enrollment_users') && $rcmail->task == 'settings' && $rcmail->action == 'plugin.twofactor_gauthenticator') {
+            // add overlay input box to html page
+            $rcmail->output->add_footer(html::tag(
+                'form',
+                array(
+                    'id' => 'enrollment_dialog',
+                    'method' => 'post'),
+                html::tag('h3', null, $this->gettext('enrollment_dialog_title')) .
+                    $this->gettext('enrollment_dialog_msg')
+            ));
+
+            $rcmail->output->add_script(
+                "$('#enrollment_dialog').show().dialog({ modal:true, resizable:false, closeOnEscape: true, width:420 });",
+                'docready'
+            );
+        }
+    }
+
+
+    // show config
+    public function twofactor_gauthenticator_init()
+    {
+        $rcmail = rcmail::get_instance();
+
         $this->add_texts('localization/', true);
         $this->register_handler('plugin.body', array($this, 'twofactor_gauthenticator_form'));
-		
+
         $rcmail->output->set_pagetitle($this->gettext('twofactor_gauthenticator'));
         $rcmail->output->send('plugin');
     }
 
     // save config
-    function twofactor_gauthenticator_save() 
+    public function twofactor_gauthenticator_save()
     {
         $rcmail = rcmail::get_instance();
 
-		// 2022-04-03: Corrected security incidente reported by kototilt@haiiro.dev
-		//					"2FA in twofactor_gauthenticator can be bypassed allowing an attacker to disable 2FA or change the TOTP secret."
-		//
-		// Solution: if user don't have session created by any rendered page, we kick out
-		$config_2FA = self::__get2FAconfig();
-		if(!$_SESSION['twofactor_gauthenticator_2FA_login'] && $config_2FA['activate']) {
-			$this->__exitSession();
-		}
-        
+        // 2022-04-03: Corrected security incidente reported by kototilt@haiiro.dev
+        //					"2FA in twofactor_gauthenticator can be bypassed allowing an attacker to disable 2FA or change the TOTP secret."
+        //
+        // Solution: if user don't have session created by any rendered page, we kick out
+        $config_2FA = self::__get2FAconfig();
+        if (!$_SESSION['twofactor_gauthenticator_2FA_login'] && $config_2FA['activate']) {
+            $this->__exitSession();
+        }
+
         $this->add_texts('localization/', true);
         $this->register_handler('plugin.body', array($this, 'twofactor_gauthenticator_form'));
         $rcmail->output->set_pagetitle($this->gettext('twofactor_gauthenticator'));
-        
+
         // POST variables
         $activate = rcube_utils::get_input_value('2FA_activate', rcube_utils::INPUT_POST);
         $secret = rcube_utils::get_input_value('2FA_secret', rcube_utils::INPUT_POST);
         $recovery_codes = rcube_utils::get_input_value('2FA_recovery_codes', rcube_utils::INPUT_POST);
-        
+
         // remove recovery codes without value
-        $recovery_codes = array_values(array_diff($recovery_codes, array('')));        
-        
+        $recovery_codes = array_values(array_diff($recovery_codes, array('')));
+
         $data = self::__get2FAconfig();
-       	$data['secret'] = $secret;
+        $data['secret'] = $secret;
         $data['activate'] = $activate ? true : false;
-       	$data['recovery_codes'] = $recovery_codes;
+        $data['recovery_codes'] = $recovery_codes;
         self::__set2FAconfig($data);
 
         // if we can't save time into SESSION, the plugin logouts
         $_SESSION['twofactor_gauthenticator_2FA_login'] = time();
-        
-		$rcmail->output->show_message($this->gettext('successfully_saved'), 'confirmation');
-         
+
+        $rcmail->output->show_message($this->gettext('successfully_saved'), 'confirmation');
+
         $rcmail->overwrite_action('plugin.twofactor_gauthenticator');
         $rcmail->output->send('plugin');
     }
-  
+
 
     // form config
-    public function twofactor_gauthenticator_form() 
+    public function twofactor_gauthenticator_form()
     {
         $rcmail = rcmail::get_instance();
-        
+
         $this->add_texts('localization/', true);
         $rcmail->output->set_env('product_name', $rcmail->config->get('product_name'));
-        
+
         $data = self::__get2FAconfig();
-                
+
         // Fields will be positioned inside of a table
         $table = new html_table(array('cols' => 2));
 
@@ -294,266 +288,266 @@ class twofactor_gauthenticator extends rcube_plugin
         $field_id = '2FA_activate';
         $checkbox_activate = new html_checkbox(array('name' => $field_id, 'id' => $field_id, 'type' => 'checkbox'));
         $table->add('title', html::label($field_id, rcube::Q($this->gettext('activate'))));
-		$checked = $data['activate'] ? null: 1; // :-?
-        $table->add(null, $checkbox_activate->show( $checked )); 
+        $checked = $data['activate'] ? null : 1; // :-?
+        $table->add(null, $checkbox_activate->show($checked));
 
-        
+
         // secret
         $field_id = '2FA_secret';
-	$input_descsecret = new html_inputfield(array('name' => $field_id, 'id' => $field_id, 'size' => 60, 'type' => 'password', 'value' => $data['secret'], 'autocomplete' => 'new-password'));
+        $input_descsecret = new html_inputfield(array('name' => $field_id, 'id' => $field_id, 'size' => 60, 'type' => 'password', 'value' => $data['secret'], 'autocomplete' => 'new-password'));
         $table->add('title', html::label($field_id, rcube::Q($this->gettext('secret'))));
         $html_secret = $input_descsecret->show();
-        if($data['secret'])
-        {
-        	$html_secret .= '<input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">';
-        }
-        else
-        {
-        	$html_secret .= '<input type="button" class="button mainaction" id="2FA_create_secret" disabled="disabled" value="'.$this->gettext('create_secret').'">';
+        if ($data['secret']) {
+            $html_secret .= '<input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">';
+        } else {
+            $html_secret .= '<input type="button" class="button mainaction" id="2FA_create_secret" disabled="disabled" value="'.$this->gettext('create_secret').'">';
         }
         $table->add(null, $html_secret);
-        
-        
+
+
         // recovery codes
-       	$table->add('title', $this->gettext('recovery_codes'));
-        	
-       	$html_recovery_codes = '';
-       	$i=0;
-       	for($i = 0; $i < $this->_number_recovery_codes; $i++)
-       	{
-       		$value = isset($data['recovery_codes'][$i]) ? $data['recovery_codes'][$i] : '';
-       		$html_recovery_codes .= ' <input type="password" name="2FA_recovery_codes[]" value="'.$value.'" maxlength="10"> &nbsp; ';
-       	}
-        if($data['secret']) {
-       		$html_recovery_codes .= '<input type="button" class="button mainaction" id="2FA_show_recovery_codes" value="'.$this->gettext('show_recovery_codes').'">';
-	}
-	else {
-       		$html_recovery_codes .= '<input type="button" class="button mainaction" id="2FA_show_recovery_codes" disabled="disabled" value="'.$this->gettext('show_recovery_codes').'">';
-	}
-       	$table->add(null, $html_recovery_codes);
-        
-        
+        $table->add('title', $this->gettext('recovery_codes'));
+
+        $html_recovery_codes = '';
+        $i = 0;
+        for ($i = 0; $i < $this->_number_recovery_codes; $i++) {
+            $value = isset($data['recovery_codes'][$i]) ? $data['recovery_codes'][$i] : '';
+            $html_recovery_codes .= ' <input type="password" name="2FA_recovery_codes[]" value="'.$value.'" maxlength="10"> &nbsp; ';
+        }
+        if ($data['secret']) {
+            $html_recovery_codes .= '<input type="button" class="button mainaction" id="2FA_show_recovery_codes" value="'.$this->gettext('show_recovery_codes').'">';
+        } else {
+            $html_recovery_codes .= '<input type="button" class="button mainaction" id="2FA_show_recovery_codes" disabled="disabled" value="'.$this->gettext('show_recovery_codes').'">';
+        }
+        $table->add(null, $html_recovery_codes);
+
+
         // qr-code
-        if($data['secret']) {
-			$table->add('title', $this->gettext('qr_code'));
-        	$table->add(null, '<input type="button" class="button mainaction" id="2FA_change_qr_code" value="'.$this->gettext('show_qr_code').'"> 
+        if ($data['secret']) {
+            $table->add('title', $this->gettext('qr_code'));
+            $table->add(null, '<input type="button" class="button mainaction" id="2FA_change_qr_code" value="'.$this->gettext('show_qr_code').'"> 
         						<div id="2FA_qr_code" style="display: none; margin-top: 10px;"></div>');
 
-        	// new JS qr-code, without call to Google
-        	$this->include_script('2FA_qr_code.js');
+            // new JS qr-code, without call to Google
+            $this->include_script('2FA_qr_code.js');
         }
-        
+
         // infor
         $table->add(null, '<td><br>'.$this->gettext('msg_infor').'</td>');
 
         // button to setup all fields if doesn't exists secret
         $html_setup_all_fields = '';
-        if(!$data['secret']) {
-        	$html_setup_all_fields = '<input type="button" class="button mainaction" id="2FA_setup_fields" value="'.$this->gettext('setup_all_fields').'">';
+        if (!$data['secret']) {
+            $html_setup_all_fields = '<input type="button" class="button mainaction" id="2FA_setup_fields" value="'.$this->gettext('setup_all_fields').'">';
         }
-        
+
         $html_check_code = '<br /><br /><input type="button" class="button mainaction" id="2FA_check_code" value="'.$this->gettext('check_code').'"> &nbsp;&nbsp; <input type="text" id="2FA_code_to_check" maxlength="10">';
-        
+
         $html_help_code = '<br /><br /> &#9432; '.$this->gettext('msg_help');
-        
+
         // Build the table with the divs around it
-        $out = html::div(array('class' => 'settingsbox', 'style' => 'margin: 0;'),
-        html::div(array('id' => 'prefs-title', 'class' => ''), $this->gettext('twofactor_gauthenticator') . ' - ' . $rcmail->user->data['username']) .  
-        html::div(array('class' => 'boxcontent'), $table->show() . 
-            html::p(null, 
-	                $rcmail->output->button(array(
-		                'command' => 'plugin.twofactor_gauthenticator-save',
-		                'type' => 'input',
-		                'class' => 'button mainaction',
-		                'label' => 'save'
-		            ))
-                
-            		// button show/hide secret
-            		//.'<input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">'
-            		
-            		// button to setup all fields
-            		.$html_setup_all_fields
-            		.$html_check_code
-            		.$html_help_code
-                )
-        	)
+        $out = html::div(
+            array('class' => 'settingsbox', 'style' => 'margin: 0;'),
+            html::div(array('id' => 'prefs-title', 'class' => ''), $this->gettext('twofactor_gauthenticator') . ' - ' . $rcmail->user->data['username']) .
+        html::div(
+            array('class' => 'boxcontent'),
+            $table->show() .
+            html::p(
+                null,
+                $rcmail->output->button(array(
+                        'command' => 'plugin.twofactor_gauthenticator-save',
+                        'type' => 'input',
+                        'class' => 'button mainaction',
+                        'label' => 'save'
+                    ))
+
+                    // button show/hide secret
+                    //.'<input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">'
+
+                    // button to setup all fields
+                    .$html_setup_all_fields
+                    .$html_check_code
+                    .$html_help_code
+            )
+        )
         );
-        
+
         // Construct the form
         $rcmail->output->add_gui_object('twofactor_gauthenticatorform', 'twofactor_gauthenticator-form');
-        
+
         $out = $rcmail->output->form_tag(array(
             'id' => 'twofactor_gauthenticator-form',
             'name' => 'twofactor_gauthenticator-form',
             'method' => 'post',
             'action' => './?_task=settings&_action=plugin.twofactor_gauthenticator-save',
         ), $out);
-	    
+
         $out = "<div class='box formcontainer scroller'>".$out."</div>";
-        
+
         return $out;
     }
-    
-    
-    // used with ajax
-    function checkCode() {
-    	$code = rcube_utils::get_input_value('code', rcube_utils::INPUT_GET);
-    	//$secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
-    	$secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
 
-    	if(self::__checkCode($code, $secret))
-    	{
-    		echo $this->gettext('code_ok');
-    	}
-    	else
-    	{
-    		echo $this->gettext('code_ko');
-    	}
-    	exit;
-    }    
-    
-	
-	//------------- private methods
-	
-	// redirect to some RC task and remove 'login' user pref
-    private function __goingRoundcubeTask($task='mail', $action=null) {
-    		
-        $_SESSION['twofactor_gauthenticator_2FA_login'] = time();
-    	header('Location: ?_task='.$task . ($action ? '&_action='.$action : '') );
-    	exit;
+
+    // used with ajax
+    public function checkCode()
+    {
+        $code = rcube_utils::get_input_value('code', rcube_utils::INPUT_GET);
+        //$secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
+        $secret = rcube_utils::get_input_value('secret', rcube_utils::INPUT_GET);
+
+        if (self::__checkCode($code, $secret)) {
+            echo $this->gettext('code_ok');
+        } else {
+            echo $this->gettext('code_ko');
+        }
+        exit;
     }
 
-    private function __exitSession() {
+
+    //------------- private methods
+
+    // redirect to some RC task and remove 'login' user pref
+    private function __goingRoundcubeTask($task = 'mail', $action = null)
+    {
+
+        $_SESSION['twofactor_gauthenticator_2FA_login'] = time();
+        header('Location: ?_task='.$task . ($action ? '&_action='.$action : ''));
+        exit;
+    }
+
+    private function __exitSession()
+    {
         unset($_SESSION['twofactor_gauthenticator_login']);
         unset($_SESSION['twofactor_gauthenticator_2FA_login']);
-    
+
         $rcmail = rcmail::get_instance();
         header('Location: ?_task=logout&_token='.$rcmail->get_request_token());
-    	exit;
+        exit;
     }
-    
-	private function __get2FAconfig()
-	{
-		$rcmail = rcmail::get_instance();
-		$user = $rcmail->user;
 
-		$arr_prefs = $user->get_prefs();
-		return $arr_prefs['twofactor_gauthenticator'] ?? null;
-	}
-	
-	// we can set array to NULL to remove
-	private function __set2FAconfig($data)
-	{
-		$rcmail = rcmail::get_instance();
-		$user = $rcmail->user;
-	
-		$arr_prefs = $user->get_prefs();
-		$arr_prefs['twofactor_gauthenticator'] = $data;
-		
-		return $user->save_prefs($arr_prefs);
-	}
-	
-	private function __isRecoveryCode($code)
-	{
-		$prefs = self::__get2FAconfig();
-		return in_array($code, $prefs['recovery_codes']);
-	}
-	
-	private function __consumeRecoveryCode($code)
-	{
-		$prefs = self::__get2FAconfig();
-		$prefs['recovery_codes'] = array_values(array_diff($prefs['recovery_codes'], array($code)));
-		
-		self::__set2FAconfig($prefs);
-	}
-	
-	
-	// GoogleAuthenticator class methods (see PHPGangsta/GoogleAuthenticator.php for more infor)
-	// returns string
-	private function __createSecret()
-	{
-		$ga = new PHPGangsta_GoogleAuthenticator();
-		return $ga->createSecret();
-	} 
-	
-	// returns string
-	private function __getSecret()
-	{
-		$prefs = self::__get2FAconfig();
-		return $prefs['secret'];
-	}	
+    private function __get2FAconfig()
+    {
+        $rcmail = rcmail::get_instance();
+        $user = $rcmail->user;
 
-	// Commented. If you have problems with qr-code.js, you can uncomment and use this
-	//
-// 	// returns string (url to img)
-// 	private function __getQRCodeGoogle()
-// 	{
-// 		$rcmail = rcmail::get_instance();
-		
-// 		$ga = new PHPGangsta_GoogleAuthenticator();
-// 		return $ga->getQRCodeGoogleUrl($rcmail->user->data['username'], self::__getSecret(), 'RoundCube2FA');
-// 	}
-	
-	// returns boolean
-	private function __checkCode($code, $secret=null)
-	{
-		$ga = new PHPGangsta_GoogleAuthenticator();
-		return $ga->verifyCode( ($secret ? $secret : self::__getSecret()), $code, 2);    // 2 = 2*30sec clock tolerance
-	} 
+        $arr_prefs = $user->get_prefs();
+        return $arr_prefs['twofactor_gauthenticator'] ?? null;
+    }
+
+    // we can set array to NULL to remove
+    private function __set2FAconfig($data)
+    {
+        $rcmail = rcmail::get_instance();
+        $user = $rcmail->user;
+
+        $arr_prefs = $user->get_prefs();
+        $arr_prefs['twofactor_gauthenticator'] = $data;
+
+        return $user->save_prefs($arr_prefs);
+    }
+
+    private function __isRecoveryCode($code)
+    {
+        $prefs = self::__get2FAconfig();
+        return in_array($code, $prefs['recovery_codes']);
+    }
+
+    private function __consumeRecoveryCode($code)
+    {
+        $prefs = self::__get2FAconfig();
+        $prefs['recovery_codes'] = array_values(array_diff($prefs['recovery_codes'], array($code)));
+
+        self::__set2FAconfig($prefs);
+    }
 
 
-	// remember option by https://github.com/corrideat/ 
-        private function __cookie($set = TRUE) {
-                $rcmail = rcmail::get_instance();
-                $user_agent = hash_hmac('md5', filter_input(INPUT_SERVER, 'USER_AGENT') ?: "\0\0\0\0\0", $rcmail->config->get('des_key'));
-                $key = hash_hmac('sha256', implode("\2\1\2", array($rcmail->user->data['username'], $this->__getSecret())), $rcmail->config->get('des_key'), TRUE);
-                $iv = hash_hmac('md5', implode("\3\2\3", array($rcmail->user->data['username'], $this->__getSecret())), $rcmail->config->get('des_key'), TRUE);
-                $name = hash_hmac('md5', $rcmail->user->data['username'], $rcmail->config->get('des_key'));
+    // GoogleAuthenticator class methods (see PHPGangsta/GoogleAuthenticator.php for more infor)
+    // returns string
+    private function __createSecret()
+    {
+        $ga = new PHPGangsta_GoogleAuthenticator();
+        return $ga->createSecret();
+    }
 
-                if ($set) {
-                    $expires = time() + 2592000; // 30 days from now
-                    $rand = mt_rand();
-                    $signature = hash_hmac('sha512', implode("\1\0\1", array($rcmail->user->data['username'], $this->__getSecret(), $user_agent, $rand, $expires)), $rcmail->config->get('des_key'), TRUE);
-                    $plain_content = sprintf("%d:%d:%s", $expires, $rand, $signature);
-                    $encrypted_content = openssl_encrypt($plain_content, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
-                    if ($encrypted_content !== false) {
-                        $b64_encrypted_content = strtr(base64_encode($encrypted_content), '+/=', '-_,');
-                        rcube_utils::setcookie($name, $b64_encrypted_content, $expires);
-                        return TRUE;
-                    }
-                    return false;
-                } else {
-                    $b64_encrypted_content = filter_input(INPUT_COOKIE, $name, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '/[a-zA-Z0-9_-]+,{0,3}/')));
-                    if (is_string($b64_encrypted_content) && !empty($b64_encrypted_content) && strlen($b64_encrypted_content)%4 === 0) {
-                        $encrypted_content = base64_decode(strtr($b64_encrypted_content, '-_,', '+/='), TRUE);
-                        if ($encrypted_content !== false) {
-                            $plain_content = openssl_decrypt($encrypted_content, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
-                            if ($plain_content !== false) {
-                                $now = time();
-                                list($expires, $rand, $signature) = explode(':', $plain_content, 3);
-                                if ($expires > $now && ($expires - $now) <= 2592000) {
-                                    $signature_verification = hash_hmac('sha512', implode("\1\0\1", array($rcmail->user->data['username'], $this->__getSecret(), $user_agent, $rand, $expires)), $rcmail->config->get('des_key'), TRUE);
-                                    // constant time
-                                    $cmp = strlen($signature) ^ strlen($signature_verification);
-                                    $signature = $signature ^ $signature_verification;
-                                    for($i = 0; $i < strlen($signature); $i++) {
-                                        $cmp += ord($signature [$i]);
-                                    }
-                                    return ($cmp===0);
-                                }
+    // returns string
+    private function __getSecret()
+    {
+        $prefs = self::__get2FAconfig();
+        return $prefs['secret'];
+    }
+
+    // Commented. If you have problems with qr-code.js, you can uncomment and use this
+    //
+    // 	// returns string (url to img)
+    // 	private function __getQRCodeGoogle()
+    // 	{
+    // 		$rcmail = rcmail::get_instance();
+
+    // 		$ga = new PHPGangsta_GoogleAuthenticator();
+    // 		return $ga->getQRCodeGoogleUrl($rcmail->user->data['username'], self::__getSecret(), 'RoundCube2FA');
+    // 	}
+
+    // returns boolean
+    private function __checkCode($code, $secret = null)
+    {
+        $ga = new PHPGangsta_GoogleAuthenticator();
+        return $ga->verifyCode(($secret ? $secret : self::__getSecret()), $code, 2);    // 2 = 2*30sec clock tolerance
+    }
+
+
+    // remember option by https://github.com/corrideat/
+    private function __cookie($set = true)
+    {
+        $rcmail = rcmail::get_instance();
+        $user_agent = hash_hmac('md5', filter_input(INPUT_SERVER, 'USER_AGENT') ?: "\0\0\0\0\0", $rcmail->config->get('des_key'));
+        $key = hash_hmac('sha256', implode("\2\1\2", array($rcmail->user->data['username'], $this->__getSecret())), $rcmail->config->get('des_key'), true);
+        $iv = hash_hmac('md5', implode("\3\2\3", array($rcmail->user->data['username'], $this->__getSecret())), $rcmail->config->get('des_key'), true);
+        $name = hash_hmac('md5', $rcmail->user->data['username'], $rcmail->config->get('des_key'));
+
+        if ($set) {
+            $expires = time() + 2592000; // 30 days from now
+            $rand = mt_rand();
+            $signature = hash_hmac('sha512', implode("\1\0\1", array($rcmail->user->data['username'], $this->__getSecret(), $user_agent, $rand, $expires)), $rcmail->config->get('des_key'), true);
+            $plain_content = sprintf("%d:%d:%s", $expires, $rand, $signature);
+            $encrypted_content = openssl_encrypt($plain_content, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+            if ($encrypted_content !== false) {
+                $b64_encrypted_content = strtr(base64_encode($encrypted_content), '+/=', '-_,');
+                rcube_utils::setcookie($name, $b64_encrypted_content, $expires);
+                return true;
+            }
+            return false;
+        } else {
+            $b64_encrypted_content = filter_input(INPUT_COOKIE, $name, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '/[a-zA-Z0-9_-]+,{0,3}/')));
+            if (is_string($b64_encrypted_content) && !empty($b64_encrypted_content) && strlen($b64_encrypted_content) % 4 === 0) {
+                $encrypted_content = base64_decode(strtr($b64_encrypted_content, '-_,', '+/='), true);
+                if ($encrypted_content !== false) {
+                    $plain_content = openssl_decrypt($encrypted_content, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv);
+                    if ($plain_content !== false) {
+                        $now = time();
+                        list($expires, $rand, $signature) = explode(':', $plain_content, 3);
+                        if ($expires > $now && ($expires - $now) <= 2592000) {
+                            $signature_verification = hash_hmac('sha512', implode("\1\0\1", array($rcmail->user->data['username'], $this->__getSecret(), $user_agent, $rand, $expires)), $rcmail->config->get('des_key'), true);
+                            // constant time
+                            $cmp = strlen($signature) ^ strlen($signature_verification);
+                            $signature = $signature ^ $signature_verification;
+                            for ($i = 0; $i < strlen($signature); $i++) {
+                                $cmp += ord($signature [$i]);
                             }
+                            return ($cmp === 0);
                         }
                     }
-                    return false;
                 }
+            }
+            return false;
         }
-	// END remember
+    }
+    // END remember
 
 
-        // log error into $_logs_file directory
-        private function __logError() {
-		$_log_dir = $rcmail->config->get('log_dir');
-                file_put_contents($_log_dir.'/'.$this->_logs_file, date("Y-m-d H:i:s")."|".$_SERVER['HTTP_X_FORWARDED_FOR']."|".$_SERVER['REMOTE_ADDR']."\n", FILE_APPEND);
-        }
-
+    // log error into $_logs_file directory
+    private function __logError()
+    {
+        $_log_dir = $rcmail->config->get('log_dir');
+        file_put_contents($_log_dir.'/'.$this->_logs_file, date("Y-m-d H:i:s")."|".$_SERVER['HTTP_X_FORWARDED_FOR']."|".$_SERVER['REMOTE_ADDR']."\n", FILE_APPEND);
+    }
 }


### PR DESCRIPTION
The code was all over the place (no offense). So I introduce a proper coding standard and linter tool. Often used in Symfony as well called: PHP-CS-Fixer: https://cs.symfony.com/

- Added a section to the README how to install & run it 👍🏽 
- Added the tool in the `tools/php-cs-fixer` directory, which is advised by https://cs.symfony.com/
- Ran the fixer; `CIDR.php`, `twofactor_gauthenticator.php` and `PHPGangsta/GoogleAuthenticator.php` look so much better now 🥇 . And readable again in my editor and a very consistent coding layout.
- Small improvements to the `config.inc.php.dist`
- Generated files/folders like `.php-cs-fixer.cache` and the `vendor` directory are ignored using `.gitignore`.
- Fixed README markdown

Preview of the new README: https://github.com/alexandregz/twofactor_gauthenticator/blob/76a97e643cf7818b9cd452cd2f9a8ecc54923a85/README.md#code-formatting
