### PR TITLE
FIx lay-out in Roundcube

### DIFF
--- a/ToDo
+++ b/ToDo
@@ -1,4 +1,3 @@
 - show errors with incorrect code, not just a logout message
 
-- IP subnet whitelisting (https://github.com/alexandregz/twofactor_gauthenticator/issues/54)
 - permanent recovery code (simon@magrin.com)

--- a/twofactor_gauthenticator.js
+++ b/twofactor_gauthenticator.js
@@ -1,5 +1,5 @@
 if (window.rcmail) {
-  rcmail.addEventListener('init', function(evt) {
+	rcmail.addEventListener('init', function(evt) {
 
 	  // ripped from PHPGansta/GoogleAuthenticator.php
 		function createSecret(secretLength) {
@@ -65,22 +65,21 @@ if (window.rcmail) {
 			$('#2FA_change_qr_code').click(click2FA_change_qr_code);
 			$('#2FA_qr_code').prop('title', '');    // enjoy the silence (qrcode.js uses text to set title)
 
-                        // white frame to dark mode, only to img generated
-                        $('#2FA_qr_code').children('img').css({
-                                'background-color': '#fff',
-                                padding: '4px'
-                        });
+			// white frame to dark mode, only to img generated
+			$('#2FA_qr_code').children('img').css({
+							'background-color': '#fff',
+							padding: '4px'
+			});
 
 			// disable save button. It needs check code to enabled again
 			$('#2FA_setup_fields').prev().attr('disabled','disabled').attr('title', rcmail.gettext('check_code_to_activate', 'twofactor_gauthenticator'));
-                       alert(rcmail.gettext('check_code_to_activate', 'twofactor_gauthenticator'));
+      alert(rcmail.gettext('check_code_to_activate', 'twofactor_gauthenticator'));
 		}
-	  
+
 	  $('#2FA_setup_fields').click(function(){
 		  setup2FAfields();
 	  });
-	  
-	  
+
 	  // to show/hide secret
 	  click2FA_change_secret = function(){
 		  if($('#2FA_secret').get(0).type == 'text') {
@@ -94,7 +93,7 @@ if (window.rcmail) {
 		  }
 	  };
 	  $('#2FA_change_secret').click(click2FA_change_secret);
-	  
+
 	  // to show/hide recovery_codes
 	  $('#2FA_show_recovery_codes').click(function(){
 
@@ -111,8 +110,7 @@ if (window.rcmail) {
 			  $('#2FA_show_recovery_codes').get(0).value = rcmail.gettext('hide_recovery_codes', 'twofactor_gauthenticator');
 		  }
 	  });
-	  
-	  
+
 	  // to show/hide qr_code
 	  click2FA_change_qr_code = function(){
 		  if( $('#2FA_qr_code').is(':visible') ) {
@@ -125,24 +123,23 @@ if (window.rcmail) {
 		  }
 	  }
 	  $('#2FA_change_qr_code').click(click2FA_change_qr_code);
-	  
+
 	  // create secret
 	  $('#2FA_create_secret').click(function(){
 		  $('#2FA_secret').get(0).value = createSecret();
 	  });
-	
-	// ajax
-	$('#2FA_check_code').click(function(){
-		url = "./?_action=plugin.twofactor_gauthenticator-checkcode&code=" +$('#2FA_code_to_check').val() + '&secret='+$('#2FA_secret').val();
-		$.post(url, function(data){
-				alert(data);
-				if(data == rcmail.gettext('code_ok', 'twofactor_gauthenticator'))
-					$('#2FA_setup_fields').prev().removeAttr('disabled');
-					
-			});
-	});
-	  
-    
+
+		// ajax
+		$('#2FA_check_code').click(function(){
+			url = "./?_action=plugin.twofactor_gauthenticator-checkcode&code=" +$('#2FA_code_to_check').val() + '&secret='+$('#2FA_secret').val();
+			$.post(url, function(data){
+					alert(data);
+					if(data == rcmail.gettext('code_ok', 'twofactor_gauthenticator'))
+						$('#2FA_setup_fields').prev().removeAttr('disabled');
+						
+				});
+		});
+
     // Define Variables
     var tabtwofactorgauthenticator = $('<li>')
       .attr('id', 'settingstabplugintwofactor_gauthenticator')

--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -90,7 +90,6 @@ class twofactor_gauthenticator extends rcube_plugin
         return true;
     }
 
-
     // Use the form login, but removing inputs with jquery and action (see twofactor_gauthenticator_form.js)
     public function login_after($args)
     {
@@ -190,7 +189,6 @@ class twofactor_gauthenticator extends rcube_plugin
         return $p;
     }
 
-
     // ripped from new_user_dialog plugin
     public function popup_msg_enrollment()
     {
@@ -215,7 +213,6 @@ class twofactor_gauthenticator extends rcube_plugin
             );
         }
     }
-
 
     // show config
     public function twofactor_gauthenticator_init()
@@ -270,7 +267,6 @@ class twofactor_gauthenticator extends rcube_plugin
         $rcmail->output->send('plugin');
     }
 
-
     // form config
     public function twofactor_gauthenticator_form()
     {
@@ -298,9 +294,9 @@ class twofactor_gauthenticator extends rcube_plugin
         $table->add('title', html::label($field_id, rcube::Q($this->gettext('secret'))));
         $html_secret = $input_descsecret->show();
         if ($data['secret']) {
-            $html_secret .= '<input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">';
+            $html_secret .= ' &nbsp; <input type="button" class="button mainaction" id="2FA_change_secret" value="'.$this->gettext('show_secret').'">';
         } else {
-            $html_secret .= '<input type="button" class="button mainaction" id="2FA_create_secret" disabled="disabled" value="'.$this->gettext('create_secret').'">';
+            $html_secret .= ' &nbsp; <input type="button" class="button mainaction" id="2FA_create_secret" disabled="disabled" value="'.$this->gettext('create_secret').'">';
         }
         $table->add(null, $html_secret);
 
@@ -347,14 +343,14 @@ class twofactor_gauthenticator extends rcube_plugin
 
         // Build the table with the divs around it
         $out = html::div(
-            array('class' => 'settingsbox', 'style' => 'margin: 0;'),
-            html::div(array('id' => 'prefs-title', 'class' => ''), $this->gettext('twofactor_gauthenticator') . ' - ' . $rcmail->user->data['username']) .
-        html::div(
-            array('class' => 'boxcontent'),
-            $table->show() .
-            html::p(
-                null,
-                $rcmail->output->button(array(
+            array('class' => 'settingsbox'),
+            html::tag('h3', array('id' => 'prefs-title', 'class' => ''), $this->gettext('twofactor_gauthenticator') . ' - ' . $rcmail->user->data['username']) .
+            html::div(
+                array('class' => 'boxcontent'),
+                $table->show() .
+                html::p(
+                    null,
+                    $rcmail->output->button(array(
                         'command' => 'plugin.twofactor_gauthenticator-save',
                         'type' => 'input',
                         'class' => 'button mainaction',
@@ -368,8 +364,8 @@ class twofactor_gauthenticator extends rcube_plugin
                     .$html_setup_all_fields
                     .$html_check_code
                     .$html_help_code
+                )
             )
-        )
         );
 
         // Construct the form
@@ -382,11 +378,10 @@ class twofactor_gauthenticator extends rcube_plugin
             'action' => './?_task=settings&_action=plugin.twofactor_gauthenticator-save',
         ), $out);
 
-        $out = "<div class='box formcontainer scroller'>".$out."</div>";
+        $out = "<div class='formcontainer'><div class='formcontent'>".$out."</div></div>";
 
         return $out;
     }
-
 
     // used with ajax
     public function checkCode()
@@ -402,7 +397,6 @@ class twofactor_gauthenticator extends rcube_plugin
         }
         exit;
     }
-
 
     //------------- private methods
 


### PR DESCRIPTION
- Fix page lay-out in Roundcube. It should be wrapped in a `formcontent` container actually
- Scroller class won't work on a formcontainer, however now I added the form to a `formcontent` scrolling bars **actually work now** as well (despite the removal of the `scroller` class)
- Additional white-space before the "Show Secret" / "Create Secret" button
- Use `h3` for the title instead of just a `div` (but keeping the `id="prefs-title"`, so I won't break any JS code)
- Fix code indentations in PHP & JS
- Remove merged TODO item.

**Before:**

![image](https://github.com/user-attachments/assets/33071d17-464e-4492-88d7-7b0602d100c1)

**After:**

![image](https://github.com/user-attachments/assets/b835991c-1450-4cb4-9c05-6a1a00d83ccf)

And like I said, scrolling also works (with scrollbar):

https://github.com/user-attachments/assets/67705e42-d02a-4e7d-b23b-80a53e672c39


