### PR TITLE
Fix error in __logError

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -541,6 +541,7 @@ class twofactor_gauthenticator extends rcube_plugin
     // log error into $_logs_file directory
     private function __logError()
     {
+        $rcmail = rcmail::get_instance();
         $_log_dir = $rcmail->config->get('log_dir');
         file_put_contents($_log_dir.'/'.$this->_logs_file, date("Y-m-d H:i:s")."|".$_SERVER['HTTP_X_FORWARDED_FOR']."|".$_SERVER['REMOTE_ADDR']."\n", FILE_APPEND);
     }


### PR DESCRIPTION
As mentioned by @EpeR1, the missing call to `rcmail::get_instance()` caused several issues. 

Fixes: #207, #215  
Partial fix for #216