### PR TITLE
Switch composer repositorie url to https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://plugins.roundcube.net"
+            "url": "https://plugins.roundcube.net"
         }
     ],
     "require": {


### PR DESCRIPTION
Composer now complains about this.

> Your configuration does not allow connections to http://plugins.roundcube.net/packages.json. See https://getcomposer.org/doc/06-config.md#secure-http for details.