### PR TITLE
Adds simple encryption to 2FA secret and codes using Roundcube DES key

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -23,3 +23,6 @@ $rcmail_config['users_allowed_2FA'] = array('ale.*@tereborace.com', 'administrat
 // Suggested by @pngd (issue 131)
 // Default: There will be no logs (false)
 $rcmail_config['enable_fail_logs'] = false;
+
+// If true, twofactor user preferences (secret and codes) will be encrypted with Roundcube's DES key.
+$rcmail_config['twofactor_pref_encrypt'] = false;


### PR DESCRIPTION
Fixes #134

This is no a perfect solution, but this way secret and codes are, at least, not stored plain text on the database.

We can improve it by hashing recovery codes and comparing hashes instead of plan text but requires some extra changes.