### PR TITLE
Changes __logError to use Roundcube's builtin write_log

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -583,8 +583,6 @@ class twofactor_gauthenticator extends rcube_plugin
     // log error into $_logs_file directory
     private function __logError()
     {
-        $rcmail = rcmail::get_instance();
-        $_log_dir = $rcmail->config->get('log_dir');
-        file_put_contents($_log_dir.'/'.$this->_logs_file, date("Y-m-d H:i:s")."|".$_SERVER['HTTP_X_FORWARDED_FOR']."|".$_SERVER['REMOTE_ADDR']."\n", FILE_APPEND);
+        rcube::write_log('twofactor_gauthenticator', "ERROR: 2FA fail - rip:". $_SERVER['HTTP_X_FORWARDED_FOR']." lip:".$_SERVER['REMOTE_ADDR']);
     }
 }


### PR DESCRIPTION
Little upgrade in function __logError() to start using Roundcube's write_log function.
This makes it more maintainable and cohesive with Roundcube logging.