### PR TITLE
Added option to reset the configuration and regenerate all fields

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -495,6 +495,10 @@ class twofactor_gauthenticator extends rcube_plugin
             $edata = $rcmail->encrypt(json_encode($data));
             $data = $edata != null ? $edata: $data;
         }
+        if ($data['activate'] != true) {
+            // if deactivated, remove all data (secret was still generated and couldn't be removed)
+            $data = array();
+        }
         $arr_prefs['twofactor_gauthenticator'] = $data;
         rcube::write_log('twofactor_gauthenticator',"WARN: 2FA may have changed!");
         return $user->save_prefs($arr_prefs);


### PR DESCRIPTION
Fixes part of [#114](https://github.com/alexandregz/twofactor_gauthenticator/issues/114)  ("Fill all fields" button doesn't exist)

If something goes wrong during the 2FA setup, you can uncheck activate and regenerate all fields.