### PR TITLE
Moved if before encrypt

### DIFF
--- a/twofactor_gauthenticator.php
+++ b/twofactor_gauthenticator.php
@@ -489,15 +489,15 @@ class twofactor_gauthenticator extends rcube_plugin
         $user = $rcmail->user;
 
         $arr_prefs = $user->get_prefs();
+        if ($data['activate'] != true) {
+            // if deactivated, remove all data (secret was still generated and couldn't be removed)
+            $data = array();
+        }
         //encrypt
         if ($data && $rcmail->config->get('twofactor_pref_encrypt'))
         {
             $edata = $rcmail->encrypt(json_encode($data));
             $data = $edata != null ? $edata: $data;
-        }
-        if ($data['activate'] != true) {
-            // if deactivated, remove all data (secret was still generated and couldn't be removed)
-            $data = array();
         }
         $arr_prefs['twofactor_gauthenticator'] = $data;
         rcube::write_log('twofactor_gauthenticator',"WARN: 2FA may have changed!");


### PR DESCRIPTION
Fix: Prevent fatal error when $rcmail_config['twofactor_pref_encrypt'] = true
Moved the activate check  before encryption to avoid accessing array offsets on a string.